### PR TITLE
Split on first ':' only.

### DIFF
--- a/opcua/uatypes.py
+++ b/opcua/uatypes.py
@@ -486,7 +486,7 @@ class QualifiedName(object):
     @staticmethod
     def from_string(string):
         if ":" in string:
-            idx, name = string.split(":")
+            idx, name = string.split(":", 1)
         else:
             idx = 0
             name = string


### PR DESCRIPTION
If the name has a ':' in it then unpacking values fails, only split on
first.