### PR TITLE
Fix string length in pack_string()

### DIFF
--- a/opcua/uatypes.py
+++ b/opcua/uatypes.py
@@ -155,6 +155,7 @@ def pack_string(string):
         return struct.pack("<i", -1)
     if not isinstance(string, bytes):
         string = string.encode()
+        length = len(string)
     return struct.pack("<i", length) + string
 
 pack_bytes = pack_string


### PR DESCRIPTION
Specification says that strings are encoded as sequences of UTF-8
characters preceded by length in bytes. But the length was calculated
as a number of UTF-8 characters. So packing of strings with
non-ASCII characters was broken.