### PR TITLE
Test for a bug in pack_string() (see pull request #13)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# coding: utf-8
 import time
 import logging
 import math
@@ -139,6 +140,17 @@ class Unit(unittest.TestCase):
         self.assertEqual(nid.NamespaceIndex, 1)
         self.assertEqual(nid.Identifier, 'titi')
         self.assertEqual(nid.NodeIdType, ua.NodeIdType.String)
+
+    def test_unicode_string_nodeid(self):
+        nid = ua.NodeId('hëllò', 1)
+        self.assertEqual(nid.NamespaceIndex, 1)
+        self.assertEqual(nid.Identifier, 'hëllò')
+        self.assertEqual(nid.NodeIdType, ua.NodeIdType.String)
+        d = nid.to_binary()
+        new_nid = nid.from_binary(io.BytesIO(d))
+        self.assertEqual(new_nid, nid)
+        self.assertEqual(new_nid.Identifier, 'hëllò')
+        self.assertEqual(new_nid.NodeIdType, ua.NodeIdType.String)
 
     def test_numeric_nodeid(self):
         nid = ua.NodeId(999, 2)


### PR DESCRIPTION
This is a small test for a bug fixed in #13.

If you try to revert #13 and then run tests, you will get the following error:
```
======================================================================
FAIL: test_unicode_string_nodeid (__main__.Unit)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 150, in test_unicode_string_nodeid
    self.assertEqual(new_nid, nid)
AssertionError: NodeId(ns=1;s=hëll) != NodeId(ns=1;s=hëllò)
----------------------------------------------------------------------
```
Note that the last letter of the node name is lost due to wrong length in the binary packet.