### PR TITLE
Explicit type for AccessLevel and UserAccessLevel

### DIFF
--- a/opcua/node.py
+++ b/opcua/node.py
@@ -199,11 +199,11 @@ class Node(object):
 
     def set_writable(self, writable=True):
         if writable:
-            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.AccessLevelMask.CurrentWrite))
-            self.set_attribute(ua.AttributeIds.UserAccessLevel, ua.DataValue(ua.AccessLevelMask.CurrentWrite))
+            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.Variant(ua.AccessLevelMask.CurrentWrite, ua.VariantType.Byte)))
+            self.set_attribute(ua.AttributeIds.UserAccessLevel, ua.DataValue(ua.Variant(ua.AccessLevelMask.CurrentWrite, ua.VariantType.Byte)))
         else:
-            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.AccessLevelMask.CurrentRead))
-            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.AccessLevelMask.CurrentRead))
+            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.Variant(ua.AccessLevelMask.CurrentRead, ua.VariantType.Byte)))
+            self.set_attribute(ua.AttributeIds.AccessLevel, ua.DataValue(ua.Variant(ua.AccessLevelMask.CurrentRead, ua.VariantType.Byte)))
 
     def set_read_only(self):
         return self.set_writable(False)

--- a/opcua/uatypes.py
+++ b/opcua/uatypes.py
@@ -737,7 +737,6 @@ class Variant(FrozenClass):
         if val is None:
             return VariantType.Null
         elif isinstance(val, bool):
-            # TDA, added this because it was missing and causes exceptions when 'bool' type is used
             return VariantType.Boolean
         elif isinstance(val, float):
             return VariantType.Double


### PR DESCRIPTION
The UaExpert is not happy with wrong type of data in AccessLevel and UserAccessLevel.

![UaExpert](https://cloud.githubusercontent.com/assets/1918204/10335597/2d1d6e24-6cf2-11e5-8e16-441337f2fc2b.png)

So the type should be explicitly set because of python types.

And one IMHO not needed comment is removed.
