### PR TITLE
Small fixes

### DIFF
--- a/opcua/binary_client.py
+++ b/opcua/binary_client.py
@@ -85,7 +85,7 @@ class UASocketClient(object):
         self.logger.debug("reading body of message (%s bytes)", size)
         data = self._socket.read(size)
         if size != len(data):
-            raise Exception("Error, did not received expected number of bytes, got {}, asked for {}".format(len(data), size))
+            raise Exception("Error, did not receive expected number of bytes, got {}, asked for {}".format(len(data), size))
         return utils.Buffer(data)
 
     def _receive(self):
@@ -99,7 +99,7 @@ class UASocketClient(object):
                 body.data = body_chunk + body.data
                 break
             elif hdr.ChunkType == b"C":
-                self.logger.debug("Received a an intermediate message with header %s, waiting for next message", hdr)
+                self.logger.debug("Received an intermediate message with header %s, waiting for next message", hdr)
                 body_chunk += body.data
             else:
                 self.logger.warning("Received a message with unknown ChunkType %s, in header %s", hdr.ChunkType, hdr)

--- a/opcua/binary_server_asyncio.py
+++ b/opcua/binary_server_asyncio.py
@@ -87,7 +87,7 @@ class BinaryServer(object):
 
         coro = self.loop.create_server(OPCUAProtocol, self.hostname, self.port)
         self._server = self.loop.run_coro_and_wait(coro)
-        print('Listening on %s:%s', self._server.sockets[0].getsockname(), self.port)
+        print('Listening on {}:{}'.format(self.hostname, self.port))
 
     def stop(self):
         print("Closing asyncio socket server")

--- a/opcua/node.py
+++ b/opcua/node.py
@@ -299,6 +299,7 @@ class Node(object):
 
         desc.NodeId = self.nodeid
         params = ua.BrowseParameters()
+        params.View.Timestamp = ua.win_epoch_to_datetime(0)
         params.NodesToBrowse.append(desc)
         results = self.server.browse(params)
         return results[0].References

--- a/opcua/uaprocessor.py
+++ b/opcua/uaprocessor.py
@@ -368,6 +368,6 @@ class UAProcessor(object):
         to be called when client has disconnected to ensure we really close
         everything we should
         """
-        print("Cleanup up client connection: ", self.name)
+        print("Cleanup client connection: ", self.name)
         if self.session:
             self.session.close_session(True)

--- a/opcua/uatypes.py
+++ b/opcua/uatypes.py
@@ -869,7 +869,7 @@ class DataValue(FrozenClass):
         return obj
 
     def __str__(self):
-        s = 'DataValue(Value:{})'.format(self.Value)
+        s = 'DataValue(Value:{}'.format(self.Value)
         if self.StatusCode is not None:
             s += ', StatusCode:{}'.format(self.StatusCode)
         if self.SourceTimestamp is not None:

--- a/opcua/utils.py
+++ b/opcua/utils.py
@@ -36,7 +36,7 @@ class Buffer(object):
         read and pop number of bytes for buffer
         """
         if size > len(self.data):
-            raise Exception("No enough data left in buffer, request for {}, we have {}".format(size, self))
+            raise Exception("Not enough data left in buffer, request for {}, we have {}".format(size, self))
         #self.logger.debug("Request for %s bytes, from %s", size, self)
         data = self.data[:size]
         self.data = self.data[size:]
@@ -57,7 +57,7 @@ class Buffer(object):
         read 'size' bytes from buffer, without removing them from buffer
         """
         if size > len(self.data):
-            raise Exception("No enough data left in buffer, request for {}, we have {}".format(size, self))
+            raise Exception("Not enough data left in buffer, request for {}, we have {}".format(size, self))
         return self.data[:size]
 
 class SocketClosedException(Exception):


### PR DESCRIPTION
Fix some typos in messages. Set zero timestamp in BrowseParameters.View, because .Net UA servers show a strange behaviour when this timestamp is a current time.