### PR TITLE
XML importer updates

### DIFF
--- a/opcua/xmlimporter.py
+++ b/opcua/xmlimporter.py
@@ -1,5 +1,5 @@
 """
-add noce defined in XML to address space
+add node defined in XML to address space
 format is the one from opc-ua specification
 """
 import logging

--- a/opcua/xmlimporter.py
+++ b/opcua/xmlimporter.py
@@ -97,7 +97,7 @@ class XmlImporter(object):
         attrs.DisplayName = ua.LocalizedText(obj.displayname)
         attrs.DataType = self.to_data_type(obj.datatype)
         # if obj.value and len(obj.value) == 1:
-        if obj.value:
+        if obj.value is not None:
             attrs.Value = ua.Variant(obj.value, getattr(ua.VariantType, obj.valuetype))
         if obj.rank:
             attrs.ValueRank = obj.rank

--- a/opcua/xmlparser.py
+++ b/opcua/xmlparser.py
@@ -89,7 +89,7 @@ class XMLParser(object):
         obj.nodetype = name
         for key, val in child.attrib.items():
             self._set_attr(key, val, obj)
-        obj.displayname = obj.browsename  # gice a default value to display name
+        obj.displayname = obj.browsename  # give a default value to display name
         for el in child:
             self._parse_tag(el, obj)
         return obj
@@ -147,9 +147,19 @@ class XMLParser(object):
         for val in el:
             ntag = self._retag.match(val.tag).groups()[1]
             obj.valuetype = ntag
-            if ntag in ("Int32", "UInt32"):
+            if ntag in ("Int8", "UInt8", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64"):
                 obj.value = int(val.text)
-            elif ntag in ('ByteString', 'String'):
+            elif ntag in ("Float", "Double"):
+                obj.value = float(val.text)
+            elif ntag in ("Boolean"):
+                if val.text in ("True", "true", "1", "on", "On"):
+                    obj.value = bool(1)
+                else:
+                    obj.value = bool(0)
+            elif ntag in ("ByteString", "String"):
+                mytext = val.text
+                if mytext is None:  # support importing null strings
+                    mytext = ""
                 mytext = val.text.replace('\n', '').replace('\r', '')
                 # obj.value.append('b"{}"'.format(mytext))
                 obj.value = mytext


### PR DESCRIPTION
Extended the xml parser to cover the basic python data types.
Fixed a bug when the xml parser tried to import a null string.
Fixed a bug where the xml importer wouldn't assign ua node data type because the imported value was a zero.