### PR TITLE
fix deadlock

### DIFF
--- a/opcua/address_space.py
+++ b/opcua/address_space.py
@@ -395,13 +395,17 @@ class AddressSpace(object):
             attval = node.attributes[attr]
             old = attval.value
             attval.value = value
+            cbs = []
             if old.Value != value.Value:  # only send call callback when a value change has happend
-                for k, v in attval.datachange_callbacks.items():
-                    try:
-                        v(k, value)
-                    except Exception as ex:
-                        self.logger.exception("Error calling datachange callback %s, %s, %s", k, v, ex)
-            return ua.StatusCode()
+                cbs = list(attval.datachange_callbacks.items())
+
+        for k, v in cbs:
+            try:
+                v(k, value)
+            except Exception as ex:
+                self.logger.exception("Error calling datachange callback %s, %s, %s", k, v, ex)
+
+        return ua.StatusCode()
 
     def add_datachange_callback(self, nodeid, attr, callback):
         with self._lock:


### PR DESCRIPTION
if two thread using internal seesion to create moniter items and change data value concurently, MonitoredItemService.create_monitored_items & AddressSpace.set_attribute_value may deadlock.

test script:
```python
import sys
sys.path.insert(0, "..")
import logging

try:
    from IPython import embed
except ImportError:
    import code

    def embed():
        vars = globals()
        vars.update(locals())
        shell = code.InteractiveConsole(vars)
        shell.interact()


from opcua import ua, uamethod, Server, Event, ObjectIds


class SubHandler(object):

    """
    Subscription Handler. To receive events from server for a subscription
    """
    def __init__(self):
        self.counter = 0

    def data_change(self, handle, node, val, attr):
        self.counter += 1
        return
        print("Python: New data change event", handle, node, val, attr)

    def event(self, handle, event):
        return
        print("Python: New event", handle, event)


# method to be exposed through server

def func(parent, variant):
    ret = False
    if variant.Value % 2 == 0:
        ret = True
    return [ua.Variant(ret, ua.VariantType.Boolean)]


# method to be exposed through server
# uses a decorator to automatically convert to and from variants

@uamethod
def multiply(parent, x, y):
    print("multiply method call with parameters: ", x, y)
    return x * y

import time
import threading


class SubThread(threading.Thread):
    def __init__(self, server, nodes):
        threading.Thread.__init__(self)
        self.lgr = logging.getLogger("SubThread")
        self.srv = server
        self.nodes = nodes
        self.daemon = True

    def run(self):
        try:
            inc_nodes(self.nodes)
        except:
            logging.Exception()
            raise

def sub_nodes(srv, nodes):
    hdl = SubHandler()
    sub = srv.create_subscription(100, hdl)
    for n in nodes:
        sub.subscribe_data_change(n)
        time.sleep(0.01)
    while 1:
        time.sleep(1)
        print hdl.counter

def inc_nodes(nodes):
    i = 0
    while 1:
        i += 1
        for n in nodes:
            n.set_value(i)
        time.sleep(0.001)


if __name__ == "__main__":
    # optional: setup logging
    logging.basicConfig(level=logging.WARN)

    # now setup our server
    server = Server()
    server.set_endpoint("opc.tcp://0.0.0.0:4841/freeopcua/server/")
    server.set_server_name("FreeOpcUa Example Server")

    # setup our own namespace
    uri = "http://examples.freeopcua.github.io"
    idx = server.register_namespace(uri)

    # get Objects node, this is where we should put our custom stuff
    objects = server.get_objects_node()

    nodes = [objects.add_variable(idx, "v%d" % i, 0) for i in range(1000)]

    # starting!
    server.start()
    print("Available loggers are: ", logging.Logger.manager.loggerDict.keys())
    try:
        # embed()
        st = SubThread(server, nodes)
        st.start()
        # inc_nodes(nodes)
        sub_nodes(server, nodes)
    finally:
        # stacktracer.stop_trace()
        server.stop()

```

example stacktrace:
```
# ThreadID: 20784
File: "c:\python27\Lib\threading.py", line 774, in __bootstrap
  self.__bootstrap_inner()
File: "c:\python27\Lib\threading.py", line 801, in __bootstrap_inner
  self.run()
File: "D:\subversion\pyopc\pyopcua\opcua\utils.py", line 135, in run
  self.loop.run_forever()
File: "c:\python27\lib\site-packages\trollius\base_events.py", line 309, in run_forever
  self._run_once()
File: "c:\python27\lib\site-packages\trollius\base_events.py", line 1217, in _run_once
  handle._run()
File: "c:\python27\lib\site-packages\trollius\events.py", line 136, in _run
  self._callback(*self._args)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 225, in _sub_loop
  self.publish_results()
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 248, in publish_results
  self.callback(result)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription.py", line 81, in publish_callback
  self.server.publish([ack])
File: "D:\subversion\pyopc\pyopcua\opcua\internal_server.py", line 264, in publish
  return self.subscription_service.publish(acks)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription_service.py", line 53, in publish
  with self._lock:
File: "c:\python27\Lib\threading.py", line 174, in acquire
  rc = self.__block.acquire(blocking)

# ThreadID: 24420
File: "c:\python27\Lib\threading.py", line 774, in __bootstrap
  self.__bootstrap_inner()
File: "c:\python27\Lib\threading.py", line 801, in __bootstrap_inner
  self.run()
File: "c:\python27\Lib\threading.py", line 754, in run
  self.__target(*self.__args, **self.__kwargs)
File: "c:\python27\lib\site-packages\concurrent\futures\thread.py", line 65, in _worker
  work_item = work_queue.get(block=True)
File: "c:\python27\Lib\Queue.py", line 168, in get
  self.not_empty.wait()
File: "c:\python27\Lib\threading.py", line 340, in wait
  waiter.acquire()

# ThreadID: 25052
File: "c:\python27\Lib\threading.py", line 774, in __bootstrap
  self.__bootstrap_inner()
File: "c:\python27\Lib\threading.py", line 801, in __bootstrap_inner
  self.run()
File: "ts.py", line 69, in run
  inc_nodes(self.nodes)
File: "ts.py", line 89, in inc_nodes
  n.set_value(i)
File: "D:\subversion\pyopc\pyopcua\opcua\node.py", line 196, in set_value
  self.set_attribute(ua.AttributeIds.Value, datavalue)
File: "D:\subversion\pyopc\pyopcua\opcua\node.py", line 229, in set_attribute
  result = self.server.write(params)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_server.py", line 216, in write
  return self.iserver.attribute_service.write(params, self.user)
File: "D:\subversion\pyopc\pyopcua\opcua\address_space.py", line 61, in write
  res.append(self._aspace.set_attribute_value(writevalue.NodeId, writevalue.AttributeId, writevalue.Value))
File: "D:\subversion\pyopc\pyopcua\opcua\address_space.py", line 401, in set_attribute_value
  v(k, value)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 141, in datachange_callback
  with self._lock:
File: "c:\python27\Lib\threading.py", line 174, in acquire
  rc = self.__block.acquire(blocking)

# ThreadID: 13040
File: "ts.py", line 143, in <module>
  sub_nodes(server, nodes)
File: "ts.py", line 78, in sub_nodes
  sub.subscribe_data_change(n)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription.py", line 127, in subscribe_data_change
  return self._subscribe(nodes, attr, queuesize=1)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription.py", line 169, in _subscribe
  mids = self.create_monitored_items(mirs)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription.py", line 207, in create_monitored_items
  results = self.server.create_monitored_items(params)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_server.py", line 243, in create_monitored_items
  return self.subscription_service.create_monitored_items(params)
File: "D:\subversion\pyopc\pyopcua\opcua\subscription_service.py", line 68, in create_monitored_items
  return self.subscriptions[params.SubscriptionId].monitored_item_srv.create_monitored_items(params)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 44, in create_monitored_items
  results.append(self._create_monitored_item(item))
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 107, in _create_monitored_item
  self.trigger_datachange(handle, params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId)
File: "D:\subversion\pyopc\pyopcua\opcua\internal_subscription.py", line 55, in trigger_datachange
  variant = self.aspace.get_attribute_value(nodeid, attr)
File: "D:\subversion\pyopc\pyopcua\opcua\address_space.py", line 366, in get_attribute_value
  with self._lock:
File: "c:\python27\Lib\threading.py", line 174, in acquire
  rc = self.__block.acquire(blocking)
```
I'm not sure the fix is in the right place. But it seems invoking callback from other source should not hold the lock.  