### PR TITLE
Clean up client's security policy API

### DIFF
--- a/opcua/binary_client.py
+++ b/opcua/binary_client.py
@@ -212,13 +212,16 @@ class BinaryClient(object):
     uaprotocol_auto.py and uaprotocol_hand.py
     """
 
-    def __init__(self, timeout=1, security_policy=ua.SecurityPolicy()):
+    def __init__(self, timeout=1):
         self.logger = logging.getLogger(__name__)
         self._publishcallbacks = {}
         self._lock = Lock()
         self._timeout = timeout
         self._uasocket = None
-        self._security_policy = security_policy
+        self._security_policy = ua.SecurityPolicy()
+
+    def set_security(self, policy):
+        self._security_policy = policy
 
     def connect_socket(self, host, port):
         """

--- a/opcua/uacrypto.py
+++ b/opcua/uacrypto.py
@@ -1,10 +1,15 @@
 import os
 
 from cryptography import x509
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hmac
 from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.ciphers import algorithms
+from cryptography.hazmat.primitives.ciphers import modes
 
 
 def load_certificate(path):
@@ -22,9 +27,19 @@ def x509_from_der(data):
     return x509.load_der_x509_certificate(data, default_backend())
 
 
+def x509_to_der(cert):
+    if not data:
+        return b''
+    return cert.public_bytes(serialization.Encoding.DER)
+
+
 def load_private_key(path):
+    _, ext = os.path.splitext(path)
     with open(path, "br") as f:
-        return serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
+        if ext == ".pem":
+            return serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
+        else:
+            return serialization.load_der_private_key(f.read(), password=None, backend=default_backend())
 
 
 def der_from_x509(certificate):
@@ -42,6 +57,15 @@ def sign_sha1(private_key, data):
     return signer.finalize()
 
 
+def verify_sha1(certificate, data, signature):
+    verifier = certificate.public_key().verifier(
+        signature,
+        padding.PKCS1v15(),
+        hashes.SHA1())
+    verifier.update(data)
+    verifier.verify()
+
+
 def encrypt_basic256(public_key, data):
     ciphertext = public_key.encrypt(
         data,
@@ -51,6 +75,90 @@ def encrypt_basic256(public_key, data):
             label=None)
     )
     return ciphertext
+
+
+def encrypt_rsa_oaep(public_key, data):
+    ciphertext = public_key.encrypt(
+        data,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA1()),
+            algorithm=hashes.SHA1(),
+            label=None)
+    )
+    return ciphertext
+
+
+def encrypt_rsa15(public_key, data):
+    ciphertext = public_key.encrypt(
+        data,
+        padding.PKCS1v15()
+    )
+    return ciphertext
+
+
+def decrypt_rsa_oaep(private_key, data):
+    text = private_key.decrypt(
+        data,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA1()),
+            algorithm=hashes.SHA1(),
+            label=None)
+    )
+    return text
+
+
+def decrypt_rsa15(private_key, data):
+    text = private_key.decrypt(
+        data,
+        padding.PKCS1v15()
+    )
+    return text
+
+
+def cipher_aes_cbc(key, init_vec):
+    return Cipher(algorithms.AES(key), modes.CBC(init_vec), default_backend())
+
+
+def cipher_encrypt(cipher, data):
+    encryptor = cipher.encryptor()
+    return encryptor.update(data) + encryptor.finalize()
+
+
+def cipher_decrypt(cipher, data):
+    decryptor = cipher.decryptor()
+    return decryptor.update(data) + decryptor.finalize()
+
+
+def hash_hmac(key, message):
+    hasher = hmac.HMAC(key, hashes.SHA1(), backend=default_backend())
+    hasher.update(message)
+    return hasher.finalize()
+
+
+def sha1_size():
+    return hashes.SHA1.digest_size
+
+
+def p_sha1(key, body, sizes=()):
+    """
+    Derive one or more keys from key and body.
+    Lengths of keys will match sizes argument
+    """
+    full_size = 0
+    for size in sizes:
+        full_size += size
+
+    result = b''
+    accum = body
+    while len(result) < full_size:
+        accum = hash_hmac(key, accum)
+        result += hash_hmac(key, accum + body)
+
+    parts = []
+    for size in sizes:
+        parts.append(result[:size])
+        result = result[size:]
+    return tuple(parts)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean up client's security policy API and move all crypto functions to uacrypto.

Added set_security() and set_security_string() methods to Client.
Removed duplicate server_certificate field, renamed
client_certificate and private_key to user_certificate and user_private_key.