### PR TITLE
Fixes

### DIFF
--- a/opcua/internal_server.py
+++ b/opcua/internal_server.py
@@ -115,7 +115,7 @@ class InternalServer(object):
                 url = url._replace(netloc=sockname[0] + ":" + str(sockname[1]))
                 edp1.EndpointUrl = url.geturl()
                 edps.append(edp1)
-                return edps
+            return edps
         return self.endpoints[:]
 
     def find_servers(self, params):

--- a/opcua/security_policies.py
+++ b/opcua/security_policies.py
@@ -249,7 +249,7 @@ class SignerAesCbc(Signer):
         return uacrypto.sha1_size()
 
     def signature(self, data):
-        return uacrypto.hash_hmac(self.key, data)
+        return uacrypto.hmac_sha1(self.key, data)
 
 
 class VerifierAesCbc(Verifier):
@@ -261,7 +261,7 @@ class VerifierAesCbc(Verifier):
         return uacrypto.sha1_size()
 
     def verify(self, data, signature):
-        expected = uacrypto.hash_hmac(self.key, data)
+        expected = uacrypto.hmac_sha1(self.key, data)
         if signature != expected:
             raise uacrypto.InvalidSignature
 
@@ -403,6 +403,7 @@ class SecurityPolicyBasic256(SecurityPolicy):
         self.client_certificate = uacrypto.der_from_x509(client_cert)
 
     def make_symmetric_key(self, nonce1, nonce2):
+        # specs part 6, 6.7.5
         key_sizes = (self.signature_key_size, self.symmetric_key_size, 16)
 
         (sigkey, key, init_vec) = uacrypto.p_sha1(nonce2, nonce1, key_sizes)

--- a/opcua/tools.py
+++ b/opcua/tools.py
@@ -475,7 +475,7 @@ def uaserver():
                         help="Populate address space with nodes defined in XML")
     parser.add_argument("-p",
                         "--populate",
-                        action="store_false",
+                        action="store_true",
                         help="Populate address space with some sample nodes")
     parser.add_argument("-c",
                         "--disable-clock",
@@ -515,13 +515,16 @@ def uaserver():
     try:
         if args.shell:
             embed()
-        else:
+        elif args.populate:
             count = 0
             while True:
                 time.sleep(1)
                 myvar.set_value(math.sin(count / 10))
                 myarrayvar.set_value([math.sin(count / 10), math.sin(count / 100)])
                 count += 1
+        else:
+            while True:
+                time.sleep(1)
     finally:
         server.stop()
     sys.exit(0)

--- a/opcua/uacrypto.py
+++ b/opcua/uacrypto.py
@@ -129,7 +129,7 @@ def cipher_decrypt(cipher, data):
     return decryptor.update(data) + decryptor.finalize()
 
 
-def hash_hmac(key, message):
+def hmac_sha1(key, message):
     hasher = hmac.HMAC(key, hashes.SHA1(), backend=default_backend())
     hasher.update(message)
     return hasher.finalize()
@@ -139,9 +139,10 @@ def sha1_size():
     return hashes.SHA1.digest_size
 
 
-def p_sha1(key, body, sizes=()):
+def p_sha1(secret, seed, sizes=()):
     """
-    Derive one or more keys from key and body.
+    Derive one or more keys from secret and seed.
+    (See specs part 6, 6.7.5 and RFC 2246 - TLS v1.0)
     Lengths of keys will match sizes argument
     """
     full_size = 0
@@ -149,10 +150,10 @@ def p_sha1(key, body, sizes=()):
         full_size += size
 
     result = b''
-    accum = body
+    accum = seed
     while len(result) < full_size:
-        accum = hash_hmac(key, accum)
-        result += hash_hmac(key, accum + body)
+        accum = hmac_sha1(secret, accum)
+        result += hmac_sha1(secret, accum + seed)
 
     parts = []
     for size in sizes:

--- a/opcua/uaprotocol_hand.py
+++ b/opcua/uaprotocol_hand.py
@@ -212,7 +212,7 @@ class AsymmetricAlgorithmHeader(uatypes.FrozenClass):
         return hdr
 
     def __str__(self):
-        return "{}(SecurytyPolicy:{}, certificatesize:{}, receiverCertificatesize:{} )".format(self.__class__.__name__, self.SecurityPolicyURI, len(self.SenderCertificate), len(self.ReceiverCertificateThumbPrint))
+        return "{}(SecurityPolicy:{}, certificatesize:{}, receiverCertificatesize:{} )".format(self.__class__.__name__, self.SecurityPolicyURI, len(self.SenderCertificate), len(self.ReceiverCertificateThumbPrint))
     __repr__ = __str__
 
 


### PR DESCRIPTION
Rename some functions in uacrypto and add comments.
In uaserver, --populate flag was inverted and uaserver didn't work without --populate (undefined variable myvar).
InternalServer always returned only the first endpoint.