### PR TITLE
Close generated address space files once the code generation is done

### DIFF
--- a/schemas/generate_address_space.py
+++ b/schemas/generate_address_space.py
@@ -39,6 +39,7 @@ class CodeGenerator(object):
                 self.make_method_code(node)
             else:
                 sys.stderr.write("Not implemented node type: " + node.nodetype + "\n")
+        self.output_file.close()
 
     def writecode(self, *args):
         self.output_file.write(" ".join(args) + "\n")


### PR DESCRIPTION
Not closing the generated files may cause some errors when trying
to interpret the files in the same script later on (i.e. parsing errors due
to half written files).