### PR TITLE
Improved loading performance when using cached address spaces

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -1,7 +1,10 @@
 from threading import RLock
 import logging
-import pickle
 from datetime import datetime
+try:
+    import cPickle as pickle
+except:
+    import pickle
 
 from opcua import ua
 from opcua.server.users import User
@@ -353,7 +356,7 @@ class AddressSpace(object):
         dump address space as binary to file
         """
         with open(path, 'wb') as f:
-            pickle.dump(self._nodes, f)
+            pickle.dump(self._nodes, f, pickle.HIGHEST_PROTOCOL)
 
     def load(self, path):
         """


### PR DESCRIPTION
Hey,

I've tried to run the python-opcua server on a Raspberry-Pi.
Unfortunately starting the server and especially the construction of the address spaces takes quite a while (~57secs), so I started to play with the already built in caching of the address spaces.

To my surprise the loading performance was much worse when loading the the address space from a pickle file (~157secs).

However, simply working with the C-Implementation of the pickle mechanism and using the latest protocol version is delivering better results (cPython: ~33 secs / cPython + HIGHEST_PROTOCOL: ~22 secs).

I didn't do any exact performance tests so you shouldn't take those values too seriously :-)
However, since other persons report similar benchmark results (e.g. http://www.benfrederickson.com/dont-pickle-your-data/), I guess it might also be a performance improvement when running on other platforms...
