### PR TITLE
Asyncio Transport Closed Explicitly, Fixes for Dumping Address Space

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -428,8 +428,11 @@ class AddressSpace(object):
         """
         dump address space as binary to file
         """
-        with open(path, 'wb') as f:
-            pickle.dump(self._nodes, f, pickle.HIGHEST_PROTOCOL)
+        try:
+            with open(path, 'wb') as f:
+                pickle.dump(self._nodes, f, pickle.HIGHEST_PROTOCOL)
+        except TypeError:
+            self.logger.info("Failed to dump address space")
 
     def load(self, path):
         """

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -335,7 +335,7 @@ class Server(object):
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.iserver.isession, nodes, recursive)
  
-     def dump_aspace(self, path):
+    def dump_aspace(self, path):
         """
         dump address space to file
         """

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -335,3 +335,14 @@ class Server(object):
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.iserver.isession, nodes, recursive)
  
+     def dump_aspace(self, path):
+        """
+        dump address space to file
+        """
+        self.iserver.dump_address_space(path)
+
+    def load_aspace(self, path):
+        """
+        load address space from file
+        """
+        self.iserver.load_address_space(path)


### PR DESCRIPTION
Fixes for issues discussed at the bottom of https://github.com/FreeOpcUa/python-opcua/issues/60 . Please review changes in binary_server_asyncio.py closely as this is the best solution I was able to come up with. Especially the while loop in stop(), this is the only way I could make sure the transport was really closed before the server is closed. Without this there seems to be a race condition.

I also added the address space dump methods back into the high level server because it seems like it could be a nice feature for people that want to back up their address space easily.

TLDR:
can't dump address space without cleaning up client connections