### PR TITLE
fix race condition in subscription

### DIFF
--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -292,7 +292,6 @@ class Subscription(object):
                     del self._monitoreditems_map[mi.RequestedParameters.ClientHandle]
                     mids.append(result.StatusCode)
                     continue
-                data = SubscriptionItemData()
                 data = self._monitoreditems_map[mi.RequestedParameters.ClientHandle]
                 data.server_handle = result.MonitoredItemId
                 mids.append(result.MonitoredItemId)

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -272,27 +272,29 @@ class Subscription(object):
         params.ItemsToCreate = monitored_items
         params.TimestampsToReturn = ua.TimestampsToReturn.Neither
 
-        mids = []
-        results = self.server.create_monitored_items(params)
-        # FIXME: Race condition here
-        # We lock as early as possible. But in some situation, a notification may arrives before
-        # locking and we will not be able to prosess it. To avoid issues, users should subscribe
-        # to all nodes at once
+        # insert monitoried item into map to avoid notification arrive before result return
+        # server_handle is left as None in purpose as we don't get it yet.
         with self._lock:
-            for idx, result in enumerate(results):
-                mi = params.ItemsToCreate[idx]
-                if not result.StatusCode.is_good():
-                    mids.append(result.StatusCode)
-                    continue
+            for mi in monitored_items:
                 data = SubscriptionItemData()
                 data.client_handle = mi.RequestedParameters.ClientHandle
                 data.node = Node(self.server, mi.ItemToMonitor.NodeId)
                 data.attribute = mi.ItemToMonitor.AttributeId
-                data.server_handle = result.MonitoredItemId
-                #data.mfilter = result.FilterResult
                 data.mfilter = mi.RequestedParameters.Filter
                 self._monitoreditems_map[mi.RequestedParameters.ClientHandle] = data
-
+        results = self.server.create_monitored_items(params)
+        mids = []
+        # process result, add server_handle, or remove it if failed
+        with self._lock:
+            for idx, result in enumerate(results):
+                mi = params.ItemsToCreate[idx]
+                if not result.StatusCode.is_good():
+                    del self._monitoreditems_map[mi.RequestedParameters.ClientHandle]
+                    mids.append(result.StatusCode)
+                    continue
+                data = SubscriptionItemData()
+                data = self._monitoreditems_map[mi.RequestedParameters.ClientHandle]
+                data.server_handle = result.MonitoredItemId
                 mids.append(result.MonitoredItemId)
         return mids
 


### PR DESCRIPTION
Insert monitored item into map to avoid notification arrive before result return. This is the way how official .net opcua library handle async nature of the subscription.