### PR TITLE
Handle Asyncio Transports Explicitly

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -64,6 +64,7 @@ class InternalServer(object):
         #importer.import_xml("/home/olivier/python-opcua/schemas/Opc.Ua.NodeSet2.xml")
 
         self.loop = utils.ThreadLoop()
+        self.asyncio_transports = []
         self.subscription_service = SubscriptionService(self.loop, self.aspace)
 
         # create a session to use on server side


### PR DESCRIPTION
Please check if this is an acceptable solution for handling the transport objects. I tested it on my local system and it seems to work (with a single client). However it should be tested more. Especially because I am not sure if calling:
```python
self.iserver.asyncio_transports.remove(self.transport)
```
in connection_lost() is really going to remove the correct object.