### PR TITLE
Add SQLite History Support for Values

### DIFF
--- a/examples/server-minimal.py
+++ b/examples/server-minimal.py
@@ -26,6 +26,10 @@ if __name__ == "__main__":
 
     # starting!
     server.start()
+    
+    # historize must be called after the server is started!
+    server.historize_node(myvar)
+    
     try:
         count = 0
         while True:

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -97,6 +97,7 @@ class InternalServer(object):
     def stop(self):
         self.logger.info("stopping internal server")
         self.loop.stop()
+        self.history_manager.stop()
 
     def _set_current_time(self):
         self.current_time_node.set_value(datetime.utcnow())

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -338,3 +338,9 @@ class Server(object):
 
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.iserver.isession, nodes, recursive)
+        
+    def historize_node(self, node):
+        self.iserver.enable_history(node)
+    
+    def dehistorize_node(self, node):
+        self.iserver.disable_history(node)


### PR DESCRIPTION
Tested this with the minimal_server.py example and it works.

Because SQLite objects have to be used on the same thread there are a few weird things that I would like feedback on. 
1. How to decide when to make a new conn object accounting for thread that is making SQL transactions?
2. How to close the SQL connections when they might have been created on other threads?

Please check it and let me know if something should be changed.