### PR TITLE
Events implementation proposal

### DIFF
--- a/examples/server-events.py
+++ b/examples/server-events.py
@@ -14,10 +14,24 @@ except ImportError:
         shell.interact()
 
 
-from opcua import ua, uamethod, Server
+from opcua import ua, uamethod, Server, EventGenerator
+
+
+class SubHandler(object):
+
+    """
+    Subscription Handler. To receive events from server for a subscription
+    """
+
+    def datachange_notification(self, node, val, data):
+        print("Python: New data change event", node, val)
+
+    def event_notification(self, event):
+        print("Python: New event", event)
 
 
 # method to be exposed through server
+
 def func(parent, variant):
     ret = False
     if variant.Value % 2 == 0:
@@ -45,11 +59,12 @@ if __name__ == "__main__":
     # logger.setLevel(logging.DEBUG)
     #logger = logging.getLogger("opcua.uaprocessor")
     # logger.setLevel(logging.DEBUG)
-    #logger = logging.getLogger("opcua.subscription_service")
-    # logger.setLevel(logging.DEBUG)
+    logger = logging.getLogger("opcua.subscription_service")
+    logger.setLevel(logging.DEBUG)
 
     # now setup our server
     server = Server()
+    #server.disable_clock()
     #server.set_endpoint("opc.tcp://localhost:4840/freeopcua/server/")
     server.set_endpoint("opc.tcp://0.0.0.0:4840/freeopcua/server/")
     server.set_server_name("FreeOpcUa Example Server")
@@ -70,32 +85,28 @@ if __name__ == "__main__":
     myarrayvar = myobj.add_variable(idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32))
     myprop = myobj.add_property(idx, "myproperty", "I am a property")
     mymethod = myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])
+    multiply_node = myobj.add_method(idx, "multiply", multiply, [ua.VariantType.Int64, ua.VariantType.Int64], [ua.VariantType.Int64])
 
-    inargx = ua.Argument()
-    inargx.Name = "x"
-    inargx.DataType = ua.NodeId(ua.ObjectIds.Int64)
-    inargx.ValueRank = -1
-    inargx.ArrayDimensions = []
-    inargx.Description = ua.LocalizedText("First number x")
-    inargy = ua.Argument()
-    inargy.Name = "y"
-    inargy.DataType = ua.NodeId(ua.ObjectIds.Int64)
-    inargy.ValueRank = -1
-    inargy.ArrayDimensions = []
-    inargy.Description = ua.LocalizedText("Second number y")
-    outarg = ua.Argument()
-    outarg.Name = "Result"
-    outarg.DataType = ua.NodeId(ua.ObjectIds.Int64)
-    outarg.ValueRank = -1
-    outarg.ArrayDimensions = []
-    outarg.Description = ua.LocalizedText("Multiplication result")
+    # creating an custom event object
+    # The custom event object automatically will have members from its parent (BaseEventType)
+    etype = server.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('MyNumericProperty', ua.VariantType.Float), ('MyStringProperty', ua.VariantType.String)])
 
-    multiply_node = myobj.add_method(idx, "multiply", multiply, [inargx, inargy], [outarg])
+    myevgen = server.get_event_generator(etype, myobj)
+    myevgen.event.Severity = 500
 
     # starting!
     server.start()
     print("Available loggers are: ", logging.Logger.manager.loggerDict.keys())
     try:
+        # enable following if you want to subscribe to nodes on server side
+        #handler = SubHandler()
+        #sub = server.create_subscription(500, handler)
+        #handle = sub.subscribe_data_change(myvar)
+        # trigger event, all subscribed clients wil receive it
+        import time
+        time.sleep(10)
+        print "Triggering event..."
+        myevgen.trigger(message="This is MyEvent with MyNumericProperty and MyStringProperty.")
 
         embed()
     finally:

--- a/examples/server-example.py
+++ b/examples/server-example.py
@@ -14,7 +14,7 @@ except ImportError:
         shell.interact()
 
 
-from opcua import ua, uamethod, Server, Event
+from opcua import ua, uamethod, Server, EventGenerator
 
 
 class SubHandler(object):

--- a/examples/server-example.py
+++ b/examples/server-example.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     # creating an event object
     # The event object automatically will have members for all events properties
-    myevgen = server.get_event_generator(ua.BaseEvent(message="This is my event", severity=300))
+    myevgen = server.get_event_generator(ua.BaseEvent(message="This is BaseEvent", severity=300))
 
     # starting!
     server.start()

--- a/examples/server-example.py
+++ b/examples/server-example.py
@@ -92,9 +92,7 @@ if __name__ == "__main__":
 
     # creating an event object
     # The event object automatically will have members for all events properties
-    myevent = server.get_event_object(ua.ObjectIds.BaseEventType)
-    myevent.Message.Text = "This is my event"
-    myevent.Severity = 300
+    myevgen = server.get_event_generator(ua.BaseEvent(message="This is my event", severity=300))
 
     # starting!
     server.start()
@@ -105,7 +103,7 @@ if __name__ == "__main__":
         #sub = server.create_subscription(500, handler)
         #handle = sub.subscribe_data_change(myvar)
         # trigger event, all subscribed clients wil receive it
-        myevent.trigger()
+        myevgen.trigger()
 
         embed()
     finally:

--- a/opcua/__init__.py
+++ b/opcua/__init__.py
@@ -10,7 +10,7 @@ Pure Python OPC-UA library
 from opcua.common.node import Node
 
 from opcua.common.methods import uamethod
-from opcua.common.event import Event
+from opcua.common.event import EventGenerator
 from opcua.common.subscription import Subscription
 from opcua.client.client import Client
 from opcua.server.server import Server

--- a/opcua/common/event.py
+++ b/opcua/common/event.py
@@ -22,36 +22,32 @@ class EventGenerator(object):
         etype: The event type, either an objectId, a NodeId or a Node object
     """
 
-    def __init__(self, isession, etype=ua.ObjectIds.BaseEventType, source=ua.ObjectIds.Server):
+    def __init__(self, isession, etype=ua.BaseEvent(), source=ua.ObjectIds.Server):
         self.isession = isession
-        self.node = None
-        self.event = etype
+        self.event = None
+        node = None
 
         if isinstance(etype, ua.BaseEvent):
-            pass
+            self.event = etype
         elif isinstance(etype, Node):
-            self.node = etype
+            node = etype
         elif isinstance(etype, ua.NodeId):
-            self.node = Node(self.isession, etype)
+            node = Node(self.isession, etype)
         else:
-            self.node = Node(self.isession, ua.NodeId(etype))
+            node = Node(self.isession, ua.NodeId(etype))
 
-        if self.node:
-            event = CustomEvent()
-            references = node.get_children_descriptions(refs=ua.ObjectIds.HasProperty)
-            for desc in references:
-                node = Node(self.isession, desc.NodeId)
-                setattr(self, desc.BrowseName.Name, node.get_value())
+        if node:
+            self.event = get_event_from_node(node)
 
         if isinstance(source, Node):
             pass
-        elif isinstance(source, NodeId):
-            source = ua.Node(isession, source)
+        elif isinstance(source, ua.NodeId):
+            source = Node(isession, source)
         else:
             source = Node(isession, ua.NodeId(source))
 
         if self.event.SourceNode.Identifier:
-            source = Node(self.iserver.isession, self.event.SourceNode)
+            source = Node(self.isession, self.event.SourceNode)
 
         self.event.SourceName = source.get_display_name().Text
         source.set_attribute(ua.AttributeIds.EventNotifier, ua.DataValue(ua.Variant(1, ua.VariantType.Byte)))
@@ -69,9 +65,9 @@ class EventGenerator(object):
             self.event.Time = time
         else:
             self.event.Time = datetime.utcnow()
-        self.event.ReciveTime = datetime.utcnow()
+        self.event.RecieveTime = datetime.utcnow()
         #FIXME: LocalTime is wrong but currently know better. For description s. Part 5 page 18
-        self.event.LocaleTime = datetime.utcnow()
+        self.event.LocalTime = datetime.utcnow()
         if message:
             self.Message = ua.LocalizedText(message)
         elif not self.event.Message:
@@ -79,15 +75,36 @@ class EventGenerator(object):
         self.isession.subscription_service.trigger_event(self.event)
 
 
+def get_event_from_node(node):
+    event = None
+    if node.nodeid.Identifier in ua.uaevents_auto.IMPLEMNTED_EVENTS.keys():
+        event = ua.uaevents_auto.IMPLEMNTED_EVENTS[node.nodeid.Identifier]()
+
+    else:
+        pass
+        #node.get
+
+        #class CustomEvent():
+
+            #pass
+    #references = node.get_children_descriptions(refs=ua.ObjectIds.HasProperty)
+    #for desc in references:
+        #child = Node(self.isession, desc.NodeId)
+        #setattr(self.event, desc.BrowseName.Name, child.get_value())
+
+    return event
+
+
 class CustomEvent(ua.BaseEvent):
 
-    def __init__(self, etype=ua.ObjectIds.BaseEventType, sourcenode=ua.NodeId(ua.ObjectIds.Server), message=None, severity=1):
-        super(ua.BaseEvent, self).__init__(sourcenode, message, severity, True)
+    def __init__(self, etype=ua.BaseEvent, sourcenode=ua.NodeId(ua.ObjectIds.Server), message=None, severity=1):
+        super(CustomEvent, self).__init__(sourcenode, message, severity, True)
         #TODO: Add fileds
 
     #TODO: Extend to show all fields of CustomEvent
     def __str__(self):
-        s = 'CustomEvent(EventId:{}'.format(self.EventId)
+        s = 'CustomEvent('
+        s += 'EventId:{}'.format(self.EventId)
         s += ', EventType:{}'.format(self.EventType)
         s += ', SourceNode:{}'.format(self.SourceNode)
         s += ', SourceName:{}'.format(self.SourceName)
@@ -97,5 +114,7 @@ class CustomEvent(ua.BaseEvent):
         s += ', Message:{}'.format(self.Message)
         s += ', Severity:{}'.format(self.Severity)
         s += ')'
+
+
         return s
     __repr__ = __str__

--- a/opcua/common/event.py
+++ b/opcua/common/event.py
@@ -6,7 +6,7 @@ from opcua import Node
 import uuid
 
 
-class Event(object):
+class EventGenerator(object):
 
     """
     Create an event based on an event type. Per default is BaseEventType used.
@@ -24,51 +24,78 @@ class Event(object):
 
     def __init__(self, isession, etype=ua.ObjectIds.BaseEventType, source=ua.ObjectIds.Server):
         self.isession = isession
+        self.node = None
+        self.event = etype
 
-        if isinstance(etype, Node):
+        if isinstance(etype, ua.BaseEvent):
+            pass
+        elif isinstance(etype, Node):
             self.node = etype
         elif isinstance(etype, ua.NodeId):
             self.node = Node(self.isession, etype)
         else:
             self.node = Node(self.isession, ua.NodeId(etype))
 
-        self._set_members_from_node(self.node)
+        if self.node:
+            event = CustomEvent()
+            references = node.get_children_descriptions(refs=ua.ObjectIds.HasProperty)
+            for desc in references:
+                node = Node(self.isession, desc.NodeId)
+                setattr(self, desc.BrowseName.Name, node.get_value())
+
         if isinstance(source, Node):
-            self.SourceNode = source.NodeId
-        elif isinstance(etype, ua.NodeId):
-            self.SourceNode = source.NodeId
+            pass
+        elif isinstance(source, NodeId):
+            source = ua.Node(isession, source)
         else:
-            self.SourceNode = ua.NodeId(source)
+            source = Node(isession, ua.NodeId(source))
 
-        # set some default values for attributes from BaseEventType, thus that all event must have
-        self.EventId = uuid.uuid4().bytes
-        self.EventType = self.node.nodeid
-        self.LocaleTime = datetime.utcnow()
-        self.ReceiveTime = datetime.utcnow()
-        self.Time = datetime.utcnow()
-        self.Message = ua.LocalizedText()
-        self.Severity = ua.Variant(1, ua.VariantType.UInt16)
-        self.SourceName = "Server"
+        if self.event.SourceNode.Identifier:
+            source = Node(self.iserver.isession, self.event.SourceNode)
 
-        # og set some node attributed we also are expected to have
-        self.BrowseName = self.node.get_browse_name()
-        self.DisplayName = self.node.get_display_name()
-        self.NodeId = self.node.nodeid
-        self.NodeClass = self.node.get_node_class()
-        self.Description = self.node.get_description()
+        self.event.SourceName = source.get_display_name().Text
+        source.set_attribute(ua.AttributeIds.EventNotifier, ua.DataValue(ua.Variant(1, ua.VariantType.Byte)))
 
     def __str__(self):
-        return "Event(Type:{}, Source:{}, Time:{}, Message: {})".format(self.EventType, self.SourceNode, self.Time, self.Message)
+        return "EventGenerator(Type:{}, Source:{}, Time:{}, Message: {})".format(self.EventType, self.SourceNode, self.Time, self.Message)
     __repr__ = __str__
 
-    def trigger(self):
+    def trigger(self, time=None, message=None):
         """
         Trigger the event. This will send a notification to all subscribed clients
         """
-        self.isession.subscription_service.trigger_event(self)
+        self.event.EventId = ua.Variant(uuid.uuid4().hex, ua.VariantType.ByteString)
+        if time:
+            self.event.Time = time
+        else:
+            self.event.Time = datetime.utcnow()
+        self.event.ReciveTime = datetime.utcnow()
+        #FIXME: LocalTime is wrong but currently know better. For description s. Part 5 page 18
+        self.event.LocaleTime = datetime.utcnow()
+        if message:
+            self.Message = ua.LocalizedText(message)
+        elif not self.event.Message:
+            self.event.Message = ua.LocalizedText(self.source.get_browse_name().Text)
+        self.isession.subscription_service.trigger_event(self.event)
 
-    def _set_members_from_node(self, node):
-        references = node.get_children_descriptions(refs=ua.ObjectIds.HasProperty)
-        for desc in references:
-            node = Node(self.isession, desc.NodeId)
-            setattr(self, desc.BrowseName.Name, node.get_value())
+
+class CustomEvent(ua.BaseEvent):
+
+    def __init__(self, etype=ua.ObjectIds.BaseEventType, sourcenode=ua.NodeId(ua.ObjectIds.Server), message=None, severity=1):
+        super(ua.BaseEvent, self).__init__(sourcenode, message, severity, True)
+        #TODO: Add fileds
+
+    #TODO: Extend to show all fields of CustomEvent
+    def __str__(self):
+        s = 'CustomEvent(EventId:{}'.format(self.EventId)
+        s += ', EventType:{}'.format(self.EventType)
+        s += ', SourceNode:{}'.format(self.SourceNode)
+        s += ', SourceName:{}'.format(self.SourceName)
+        s += ', Time:{}'.format(self.Time)
+        s += ', RecieveTime:{}'.format(self.RecieveTime)
+        s += ', LocalTime:{}'.format(self.LocalTime)
+        s += ', Message:{}'.format(self.Message)
+        s += ', Severity:{}'.format(self.Severity)
+        s += ')'
+        return s
+    __repr__ = __str__

--- a/opcua/common/event.py
+++ b/opcua/common/event.py
@@ -115,8 +115,6 @@ def get_event_properties_from_type_node(node):
     properties = []
     curr_node = node
 
-    print node
-
     while True:
         properties.extend(curr_node.get_properties())
 

--- a/opcua/common/node.py
+++ b/opcua/common/node.py
@@ -369,6 +369,10 @@ class Node(object):
         from opcua.common import manage_nodes
         return manage_nodes.create_method(*args, **kwargs)
 
+    def add_subtype(*args, **kwargs):
+        from opcua.common import manage_nodes
+        return manage_nodes.create_subtype(*args, **kwargs)
+
     def call_method(*args, **kwargs):
         from opcua.common import methods
         return methods.call_method(*args, **kwargs)

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -7,6 +7,7 @@ from threading import Lock
 
 from opcua import ua
 from opcua import Node
+from opcua.common import event
 
 
 class SubHandler(object):
@@ -201,11 +202,11 @@ class Subscription(object):
     def _get_filter_from_event_type(self, eventtype):
         eventtype = self._get_node(eventtype)
         evfilter = ua.EventFilter()
-        for desc in eventtype.get_children_descriptions(refs=ua.ObjectIds.HasProperty, nodeclassmask=ua.NodeClass.Variable):
+        for property in event.get_event_properties_from_type_node(eventtype):
             op = ua.SimpleAttributeOperand()
             op.TypeDefinitionId = eventtype.nodeid
             op.AttributeId = ua.AttributeIds.Value
-            op.BrowsePath = [desc.BrowseName]
+            op.BrowsePath = [property.get_browse_name()]
             evfilter.SelectClauses.append(op)
         return evfilter
 

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -39,12 +39,6 @@ class SubHandler(object):
         """
         pass
 
-    def event(self, handle, event):
-        """
-        Deprecated use event_notification
-        """
-        pass
-
 
 class EventResult():
     """

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -459,7 +459,7 @@ class AddressSpace(object):
 
     def get_attribute_value(self, nodeid, attr):
         with self._lock:
-            #self.logger.debug("get attr val: %s %s", nodeid, attr)
+            self.logger.debug("get attr val: %s %s", nodeid, attr)
             if nodeid not in self._nodes:
                 dv = ua.DataValue()
                 dv.StatusCode = ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown)

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -338,7 +338,7 @@ class Server(object):
             etype = ua.BaseEvent()
         return EventGenerator(self.iserver.isession, etype, source)
 
-    def create_custom_event(self, idx, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
+    def create_custom_event_type(self, idx, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
 
         if isinstance(baseetype, Node):
             base_event = baseetype

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -329,12 +329,14 @@ class Server(object):
         """
         return EventGenerator(self.iserver.isession, etype, source)
 
-    def create_custom_event(self, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
+    def create_custom_event(self, idx, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
 
-        base_event = self.get_node(baseetype)
-        custom_event = base_event.add_object(name)
+        base_event = self.get_node(ua.NodeId(baseetype))
+        custom_event = base_event.add_subtype(idx, name)
         for property in properties:
-            custom_event.add_property(property[0], property[1])
+            custom_event.add_property(idx, property[0], ua.Variant(None, property[1]))
+
+        return custom_event
 
     def import_xml(self, path):
         """

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -329,16 +329,24 @@ class Server(object):
         uries = self.get_namespace_array()
         return uries.index(uri)
 
-    def get_event_generator(self, etype=ua.BaseEvent(), source=ua.ObjectIds.Server):
+    def get_event_generator(self, etype=None, source=ua.ObjectIds.Server):
         """
         Returns an event object using an event type from address space.
         Use this object to fire events
         """
+        if not etype:
+            etype = ua.BaseEvent()
         return EventGenerator(self.iserver.isession, etype, source)
 
     def create_custom_event(self, idx, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
 
-        base_event = self.get_node(ua.NodeId(baseetype))
+        if isinstance(baseetype, Node):
+            base_event = baseetype
+        elif isinstance(baseetype, ua.NodeId):
+            base_event = Node(self.iserver.isession, baseetype)
+        else:
+            base_event = Node(self.iserver.isession, ua.NodeId(baseetype))
+
         custom_event = base_event.add_subtype(idx, name)
         for property in properties:
             custom_event.add_property(idx, property[0], ua.Variant(None, property[1]))

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -14,7 +14,7 @@ from opcua import ua
 from opcua.server.binary_server_asyncio import BinaryServer
 from opcua.server.internal_server import InternalServer
 from opcua.common.node import Node
-from opcua.common.event import Event
+from opcua.common.event import EventGenerator
 from opcua.common.subscription import Subscription
 from opcua.common import xmlimporter
 from opcua.common.manage_nodes import delete_nodes
@@ -322,12 +322,19 @@ class Server(object):
         uries = self.get_namespace_array()
         return uries.index(uri)
 
-    def get_event_object(self, etype=ua.ObjectIds.BaseEventType, source=ua.ObjectIds.Server):
+    def get_event_generator(self, etype=ua.ObjectIds.BaseEventType, source=ua.ObjectIds.Server):
         """
         Returns an event object using an event type from address space.
         Use this object to fire events
         """
-        return Event(self.iserver.isession, etype, source)
+        return EventGenerator(self.iserver.isession, etype, source)
+
+    def create_custom_event(self, name, baseetype=ua.ObjectIds.BaseEventType, properties=[]):
+
+        base_event = self.get_node(baseetype)
+        custom_event = base_event.add_object(name)
+        for property in properties:
+            custom_event.add_property(property[0], property[1])
 
     def import_xml(self, path):
         """
@@ -338,9 +345,9 @@ class Server(object):
 
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.iserver.isession, nodes, recursive)
-        
+
     def historize_node(self, node):
         self.iserver.enable_history(node)
-    
+
     def dehistorize_node(self, node):
         self.iserver.disable_history(node)

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -322,7 +322,7 @@ class Server(object):
         uries = self.get_namespace_array()
         return uries.index(uri)
 
-    def get_event_generator(self, etype=ua.ObjectIds.BaseEventType, source=ua.ObjectIds.Server):
+    def get_event_generator(self, etype=ua.BaseEvent(), source=ua.ObjectIds.Server):
         """
         Returns an event object using an event type from address space.
         Use this object to fire events

--- a/opcua/ua/__init__.py
+++ b/opcua/ua/__init__.py
@@ -4,6 +4,6 @@ from opcua.ua.object_ids import ObjectIds
 from opcua.ua.status_codes import StatusCodes
 from opcua.ua.uaprotocol_auto import *
 from opcua.ua.uaprotocol_hand import *
-from opcua.ua.uatypes_auto import *
 from opcua.ua.uatypes import *  #TODO: This should be renamed to uatypes_hand
+from opcua.ua.uaevents_auto import *
 

--- a/opcua/ua/__init__.py
+++ b/opcua/ua/__init__.py
@@ -4,4 +4,6 @@ from opcua.ua.object_ids import ObjectIds
 from opcua.ua.status_codes import StatusCodes
 from opcua.ua.uaprotocol_auto import *
 from opcua.ua.uaprotocol_hand import *
+from opcua.ua.uatypes_auto import *
+from opcua.ua.uatypes import *  #TODO: This should be renamed to uatypes_hand
 

--- a/opcua/ua/uaevents_auto.py
+++ b/opcua/ua/uaevents_auto.py
@@ -6,12 +6,13 @@ For now only events!
 
 from opcua.ua import *
 
+
 # TODO: This should be autogeneratd form XML description of EventTypes
 class BaseEvent(FrozenClass):
     '''
     BaseEvent implements BaseEventType from which inherit all other events and it is used per default.
     '''
-    def __init__(self, sourcenode=NodeId(ObjectIds.Server), message=None, severity=1, extended=False):
+    def __init__(self, sourcenode=None, message=None, severity=1, extended=False):
         self.EventId = bytes()
         self.EventType = NodeId(ObjectIds.BaseEventType)
         self.SourceNode = sourcenode
@@ -25,20 +26,27 @@ class BaseEvent(FrozenClass):
             self._freeze = True
 
     def __str__(self):
-        s = 'BaseEventType(EventId:{}'.format(self.EventId)
-        s += ', EventType:{}'.format(self.EventType)
-        s += ', SourceNode:{}'.format(self.SourceNode)
-        s += ', SourceName:{}'.format(self.SourceName)
-        s += ', Time:{}'.format(self.Time)
-        s += ', RecieveTime:{}'.format(self.RecieveTime)
-        s += ', LocalTime:{}'.format(self.LocalTime)
-        s += ', Message:{}'.format(self.Message)
-        s += ', Severity:{}'.format(self.Severity)
-        s += ')'
-        return s
+        return "{}({})".format(type(self).__name__, [str(k) + ":" + str(v) for k, v in self.__dict__.items()])
     __repr__ = __str__
+
+
+class AuditEvent(BaseEvent):
+    '''
+    Audit implements AuditEventType from which inherit all other Audit events.
+    '''
+    def __init__(self, sourcenode=None, message=None, severity=1, extended=False):
+        super(AuditEvent, self).__init__(sourcenode, message, severity, True)
+
+        self.ActionTimeStamp = None
+        self.Status = False
+        self.ServerId = None
+        self.ClientAuditEntryId = None
+        self.ClientUserId = None
+        if not extended:
+            self._freeze = True
 
 
 IMPLEMNTED_EVENTS = {
     ObjectIds.BaseEventType: BaseEvent,
+    ObjectIds.AuditEventType: AuditEvent,
     }

--- a/opcua/ua/uaevents_auto.py
+++ b/opcua/ua/uaevents_auto.py
@@ -36,6 +36,7 @@ class AuditEvent(BaseEvent):
     '''
     def __init__(self, sourcenode=None, message=None, severity=1, extended=False):
         super(AuditEvent, self).__init__(sourcenode, message, severity, True)
+        self.EventType = NodeId(ObjectIds.AuditEventType)
 
         self.ActionTimeStamp = None
         self.Status = False
@@ -46,7 +47,7 @@ class AuditEvent(BaseEvent):
             self._freeze = True
 
 
-IMPLEMNTED_EVENTS = {
+IMPLEMENTED_EVENTS = {
     ObjectIds.BaseEventType: BaseEvent,
     ObjectIds.AuditEventType: AuditEvent,
     }

--- a/opcua/ua/uaevents_auto.py
+++ b/opcua/ua/uaevents_auto.py
@@ -6,10 +6,8 @@ For now only events!
 
 from opcua.ua import *
 
-
 # TODO: This should be autogeneratd form XML description of EventTypes
 class BaseEvent(FrozenClass):
-
     '''
     BaseEvent implements BaseEventType from which inherit all other events and it is used per default.
     '''
@@ -39,3 +37,8 @@ class BaseEvent(FrozenClass):
         s += ')'
         return s
     __repr__ = __str__
+
+
+IMPLEMNTED_EVENTS = {
+    ObjectIds.BaseEventType: BaseEvent,
+    }

--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -1068,8 +1068,6 @@ class XmlElement(FrozenClass):
     __repr__ = __str__
 
 
-
-
 class DataValue(FrozenClass):
 
     '''

--- a/opcua/ua/uatypes_auto.py
+++ b/opcua/ua/uatypes_auto.py
@@ -1,0 +1,41 @@
+'''
+Example auto_generated file with UA Types
+
+For now only events!
+'''
+
+from opcua.ua import *
+
+
+# TODO: This should be autogeneratd form XML description of EventTypes
+class BaseEvent(FrozenClass):
+
+    '''
+    BaseEvent implements BaseEventType from which inherit all other events and it is used per default.
+    '''
+    def __init__(self, sourcenode=NodeId(ObjectIds.Server), message=None, severity=1, extended=False):
+        self.EventId = bytes()
+        self.EventType = NodeId(ObjectIds.BaseEventType)
+        self.SourceNode = sourcenode
+        self.SourceName = None
+        self.Time = None
+        self.RecieveTime = None
+        self.LocalTime = None
+        self.Message = LocalizedText(message)
+        self.Severity = Variant(severity, VariantType.UInt16)
+        if not extended:
+            self._freeze = True
+
+    def __str__(self):
+        s = 'BaseEventType(EventId:{}'.format(self.EventId)
+        s += ', EventType:{}'.format(self.EventType)
+        s += ', SourceNode:{}'.format(self.SourceNode)
+        s += ', SourceName:{}'.format(self.SourceName)
+        s += ', Time:{}'.format(self.Time)
+        s += ', RecieveTime:{}'.format(self.RecieveTime)
+        s += ', LocalTime:{}'.format(self.LocalTime)
+        s += ', Message:{}'.format(self.Message)
+        s += ', Severity:{}'.format(self.Severity)
+        s += ')'
+        return s
+    __repr__ = __str__

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -1,12 +1,12 @@
 # encoding: utf-8
-from concurrent.futures import Future
+from concurrent.futures import Future, TimeoutError
 import time
 from datetime import datetime
 from datetime import timedelta
 import math
 
+import opcua
 from opcua import ua
-from opcua import EventGenerator
 from opcua import uamethod
 
 
@@ -288,29 +288,162 @@ class CommonTests(object):
             handle = sub.subscribe_events(v)
         sub.delete()
 
-    #def test_events(self):
-        #msclt = MySubHandler()
-        #sub = self.opc.create_subscription(100, msclt)
-        #handle = sub.subscribe_events()
+    def test_get_event_from_type_node_BaseEvent(self):
+        etype = self.opc.get_node(ua.ObjectIds.BaseEventType)
+        properties = opcua.common.event.get_event_properties_from_type_node(etype)
+        for child in etype.get_properties():
+            self.assertTrue(child in properties)
 
-        #ev = EventGenerator(self.srv.iserver.isession)
-        #msg = b"this is my msg "
-        #ev.Message.Text = msg
-        #tid = datetime.utcnow()
-        #ev.Time = tid
-        #ev.Severity = 500
-        #ev.trigger()
+    def test_get_event_from_type_node_CustomEvent(self):
+        etype = self.srv.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.AuditEventType, [('PropertyNum', ua.VariantType.Float), ('PropertyString', ua.VariantType.String)])
 
-        #ev = msclt.future.result()
-        #self.assertIsNot(ev, None)  # we did not receive event
-        #self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
-        #self.assertEqual(ev.Message.Text, msg)
-        ##self.assertEqual(msclt.ev.Time, tid)
-        #self.assertEqual(ev.Severity, 500)
+        properties = opcua.common.event.get_event_properties_from_type_node(etype)
 
-        ## time.sleep(0.1)
-        #sub.unsubscribe(handle)
-        #sub.delete()
+        for child in self.opc.get_node(ua.ObjectIds.BaseEventType).get_properties():
+            self.assertTrue(child in properties)
+        for child in self.opc.get_node(ua.ObjectIds.AuditEventType).get_properties():
+            self.assertTrue(child in properties)
+        for child in self.opc.get_node(etype.nodeid).get_properties():
+                self.assertTrue(child in properties)
+
+        self.assertTrue(etype.get_child("2:PropertyNum") in properties)
+        self.assertTrue(etype.get_child("2:PropertyString") in properties)
+
+    def test_events_default(self):
+        evgen = self.srv.get_event_generator()
+
+        msclt = MySubHandler()
+        sub = self.opc.create_subscription(100, msclt)
+        handle = sub.subscribe_events()
+
+        tid = datetime.utcnow()
+        msg = b"this is my msg "
+        evgen.trigger(tid, msg)
+
+        ev = msclt.future.result()
+        self.assertIsNot(ev, None)  # we did not receive event
+        self.assertEqual(ev.EventType, ua.NodeId(ua.ObjectIds.BaseEventType))
+        self.assertEqual(ev.Severity, 1)
+        self.assertEqual(ev.SourceName, self.opc.get_server_node().get_display_name().Text)
+        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
+        self.assertEqual(ev.Message.Text, msg)
+        self.assertEqual(ev.Time, tid)
+
+        # time.sleep(0.1)
+        sub.unsubscribe(handle)
+        sub.delete()
+
+    def test_events_MyObject(self):
+        objects = self.srv.get_objects_node()
+        o = objects.add_object(3, 'MyObject')
+        evgen = self.srv.get_event_generator(source=o)
+
+        msclt = MySubHandler()
+        sub = self.opc.create_subscription(100, msclt)
+        handle = sub.subscribe_events(o)
+
+        tid = datetime.utcnow()
+        msg = b"this is my msg "
+        evgen.trigger(tid, msg)
+
+        ev = msclt.future.result(10)
+        self.assertIsNot(ev, None)  # we did not receive event
+        self.assertEqual(ev.EventType, ua.NodeId(ua.ObjectIds.BaseEventType))
+        self.assertEqual(ev.Severity, 1)
+        self.assertEqual(ev.SourceName, "MyObject")
+        self.assertEqual(ev.SourceNode, o.nodeid)
+        self.assertEqual(ev.Message.Text, msg)
+        self.assertEqual(ev.Time, tid)
+
+        # time.sleep(0.1)
+        sub.unsubscribe(handle)
+        sub.delete()
+
+    def test_events_wrong_source(self):
+        objects = self.srv.get_objects_node()
+        o = objects.add_object(3, 'MyObject')
+        evgen = self.srv.get_event_generator(source=o)
+
+        msclt = MySubHandler()
+        sub = self.opc.create_subscription(100, msclt)
+        handle = sub.subscribe_events()
+
+        tid = datetime.utcnow()
+        msg = b"this is my msg "
+        evgen.trigger(tid, msg)
+
+        with self.assertRaises(TimeoutError):  # we should not receive event
+            ev = msclt.future.result(10)
+
+        # time.sleep(0.1)
+        sub.unsubscribe(handle)
+        sub.delete()
+
+    def test_events_CustomEvent(self):
+        etype = self.srv.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('PropertyNum', ua.VariantType.Float), ('PropertyString', ua.VariantType.String)])
+        evgen = self.srv.get_event_generator(etype)
+
+        msclt = MySubHandler()
+        sub = self.opc.create_subscription(100, msclt)
+        handle = sub.subscribe_events(evtype=etype)
+
+        propertynum = 2
+        propertystring = "This is my test"
+        evgen.event.PropertyNum = propertynum
+        evgen.event.PropertyString = propertystring
+        serverity = 500
+        evgen.event.Severity = serverity
+        tid = datetime.utcnow()
+        msg = b"this is my msg "
+        evgen.trigger(tid, msg)
+
+        ev = msclt.future.result(10)
+        self.assertIsNot(ev, None)  # we did not receive event
+        self.assertEqual(ev.EventType, etype.nodeid)
+        self.assertEqual(ev.Severity, serverity)
+        self.assertEqual(ev.SourceName, self.opc.get_server_node().get_display_name().Text)
+        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
+        self.assertEqual(ev.Message.Text, msg)
+        self.assertEqual(ev.Time, tid)
+        self.assertEqual(ev.PropertyNum, propertynum)
+        self.assertEqual(ev.PropertyString, propertystring)
+
+        # time.sleep(0.1)
+        sub.unsubscribe(handle)
+        sub.delete()
+
+    def test_events_CustomEvent_MyObject(self):
+        objects = self.srv.get_objects_node()
+        o = objects.add_object(3, 'MyObject')
+        etype = self.srv.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('PropertyNum', ua.VariantType.Float), ('PropertyString', ua.VariantType.String)])
+        evgen = self.srv.get_event_generator(etype, o)
+
+        msclt = MySubHandler()
+        sub = self.opc.create_subscription(100, msclt)
+        handle = sub.subscribe_events(o, etype)
+
+        propertynum = 2
+        propertystring = "This is my test"
+        evgen.event.PropertyNum = propertynum
+        evgen.event.PropertyString = propertystring
+        tid = datetime.utcnow()
+        msg = b"this is my msg "
+        evgen.trigger(tid, msg)
+
+        ev = msclt.future.result(10)
+        self.assertIsNot(ev, None)  # we did not receive event
+        self.assertEqual(ev.EventType, etype.nodeid)
+        self.assertEqual(ev.Severity, 1)
+        self.assertEqual(ev.SourceName, "MyObject")
+        self.assertEqual(ev.SourceNode, o.nodeid)
+        self.assertEqual(ev.Message.Text, msg)
+        self.assertEqual(ev.Time, tid)
+        self.assertEqual(ev.PropertyNum, propertynum)
+        self.assertEqual(ev.PropertyString, propertystring)
+
+        # time.sleep(0.1)
+        sub.unsubscribe(handle)
+        sub.delete()
 
     def test_non_existing_path(self):
         root = self.opc.get_root_node()

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -350,7 +350,7 @@ class CommonTests(object):
         self.assertIsNot(ev, None)  # we did not receive event
         self.assertEqual(ev.EventType, ua.NodeId(ua.ObjectIds.BaseEventType))
         self.assertEqual(ev.Severity, 1)
-        self.assertEqual(ev.SourceName, "MyObject")
+        self.assertEqual(ev.SourceName, b'MyObject')
         self.assertEqual(ev.SourceNode, o.nodeid)
         self.assertEqual(ev.Message.Text, msg)
         self.assertEqual(ev.Time, tid)
@@ -434,7 +434,7 @@ class CommonTests(object):
         self.assertIsNot(ev, None)  # we did not receive event
         self.assertEqual(ev.EventType, etype.nodeid)
         self.assertEqual(ev.Severity, 1)
-        self.assertEqual(ev.SourceName, "MyObject")
+        self.assertEqual(ev.SourceName, b'MyObject')
         self.assertEqual(ev.SourceNode, o.nodeid)
         self.assertEqual(ev.Message.Text, msg)
         self.assertEqual(ev.Time, tid)

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -6,9 +6,8 @@ from datetime import timedelta
 import math
 
 from opcua import ua
-from opcua import Event
+from opcua import EventGenerator
 from opcua import uamethod
-from opcua import Event
 
 
 def add_server_methods(srv):
@@ -23,7 +22,7 @@ def add_server_methods(srv):
     def func2(parent, methodname, value):
         return math.sin(value)
 
-    o = srv.get_objects_node()š
+    o = srv.get_objects_node()
     v = o.add_method(ua.NodeId("ServerMethodArray", 2), ua.QualifiedName('ServerMethodArray', 2), func2, [ua.VariantType.String, ua.VariantType.Int64], [ua.VariantType.Int64])
 
     @uamethod
@@ -263,29 +262,29 @@ class CommonTests(object):
             handle = sub.subscribe_events(v)
         sub.delete()
 
-    def test_events(self):
-        msclt = MySubHandler()
-        sub = self.opc.create_subscription(100, msclt)
-        handle = sub.subscribe_events()
+    #def test_events(self):
+        #msclt = MySubHandler()
+        #sub = self.opc.create_subscription(100, msclt)
+        #handle = sub.subscribe_events()
 
-        ev = Event(self.srv.iserver.isession)
-        msg = b"this is my msg "
-        ev.Message.Text = msg
-        tid = datetime.utcnow()
-        ev.Time = tid
-        ev.Severity = 500
-        ev.trigger()
+        #ev = EventGenerator(self.srv.iserver.isession)
+        #msg = b"this is my msg "
+        #ev.Message.Text = msg
+        #tid = datetime.utcnow()
+        #ev.Time = tid
+        #ev.Severity = 500
+        #ev.trigger()
 
-        ev = msclt.future.result()
-        self.assertIsNot(ev, None)  # we did not receive event
-        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
-        self.assertEqual(ev.Message.Text, msg)
-        #self.assertEqual(msclt.ev.Time, tid)
-        self.assertEqual(ev.Severity, 500)
+        #ev = msclt.future.result()
+        #self.assertIsNot(ev, None)  # we did not receive event
+        #self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
+        #self.assertEqual(ev.Message.Text, msg)
+        ##self.assertEqual(msclt.ev.Time, tid)
+        #self.assertEqual(ev.Severity, 500)
 
-        # time.sleep(0.1)
-        sub.unsubscribe(handle)
-        sub.delete()
+        ## time.sleep(0.1)
+        #sub.unsubscribe(handle)
+        #sub.delete()
 
     def test_non_existing_path(self):
         root = self.opc.get_root_node()

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -23,7 +23,7 @@ def add_server_methods(srv):
     def func2(parent, methodname, value):
         return math.sin(value)
 
-    o = srv.get_objects_node()
+    o = srv.get_objects_node()š
     v = o.add_method(ua.NodeId("ServerMethodArray", 2), ua.QualifiedName('ServerMethodArray', 2), func2, [ua.VariantType.String, ua.VariantType.Int64], [ua.VariantType.Int64])
 
     @uamethod
@@ -86,7 +86,7 @@ class MySubHandler():
 
 class MySubHandler2():
     def __init__(self):
-        self.results = [] 
+        self.results = []
 
     def datachange_notification(self, node, val, data):
         self.results.append((node, val))
@@ -97,8 +97,8 @@ class MySubHandler2():
 
 class MySubHandlerCounter():
     def __init__(self):
-        self.datachange_count = 0 
-        self.event_count = 0 
+        self.datachange_count = 0
+        self.event_count = 0
 
     def datachange_notification(self, node, val, data):
         self.datachange_count += 1
@@ -263,30 +263,6 @@ class CommonTests(object):
             handle = sub.subscribe_events(v)
         sub.delete()
 
-    def test_events_deprecated(self):
-        msclt = MySubHandlerDeprecated()
-        sub = self.opc.create_subscription(100, msclt)
-        handle = sub.subscribe_events()
-
-        ev = Event(self.srv.iserver.isession)
-        msg = b"this is my msg "
-        ev.Message.Text = msg
-        tid = datetime.utcnow()
-        ev.Time = tid
-        ev.Severity = 500
-        ev.trigger()
-
-        clthandle, ev = msclt.future.result()
-        self.assertIsNot(ev, None)  # we did not receive event
-        self.assertEqual(ev.Message.Text, msg)
-        #self.assertEqual(msclt.ev.Time, tid)
-        self.assertEqual(ev.Severity, 500)
-        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
-
-        # time.sleep(0.1)
-        sub.unsubscribe(handle)
-        sub.delete()
-
     def test_events(self):
         msclt = MySubHandler()
         sub = self.opc.create_subscription(100, msclt)
@@ -302,10 +278,10 @@ class CommonTests(object):
 
         ev = msclt.future.result()
         self.assertIsNot(ev, None)  # we did not receive event
+        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
         self.assertEqual(ev.Message.Text, msg)
         #self.assertEqual(msclt.ev.Time, tid)
         self.assertEqual(ev.Severity, 500)
-        self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
 
         # time.sleep(0.1)
         sub.unsubscribe(handle)
@@ -387,7 +363,7 @@ class CommonTests(object):
     def test_utf8(self):
         objects = self.opc.get_objects_node()
         utf_string = "æøå@%&"
-        bn = ua.QualifiedName(utf_string, 3) 
+        bn = ua.QualifiedName(utf_string, 3)
         nid = ua.NodeId("æølå", 3)
         val = "æøå"
         v = objects.add_variable(nid, bn, val)
@@ -747,7 +723,7 @@ class CommonTests(object):
         o = self.opc.get_objects_node()
 
         # subscribe to a variable
-        startv1 = True 
+        startv1 = True
         v1 = o.add_variable(3, 'SubscriptionVariableBool', startv1)
         sub = self.opc.create_subscription(100, msclt)
         handle1 = sub.subscribe_data_change(v1)
@@ -777,9 +753,9 @@ class CommonTests(object):
         msclt = MySubHandler2()
         o = self.opc.get_objects_node()
 
-        startv1 = True 
+        startv1 = True
         v1 = o.add_variable(3, 'SubscriptionVariableMany1', startv1)
-        startv2 = [1.22, 1.65] 
+        startv2 = [1.22, 1.65]
         v2 = o.add_variable(3, 'SubscriptionVariableMany2', startv2)
 
         sub = self.opc.create_subscription(100, msclt)
@@ -787,7 +763,7 @@ class CommonTests(object):
 
         # Now check we get the start values
         nodes = [v1, v2]
-       
+
         count = 0
         while not len(msclt.results) > 1:
             count += 1
@@ -804,7 +780,7 @@ class CommonTests(object):
             else:
                 self.fail("Error node {} is neither {} nor {}".format(node, v1, v2))
 
-        sub.delete() 
+        sub.delete()
 
     def test_subscribe_server_time(self):
         msclt = MySubHandler()

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -142,6 +142,17 @@ class TestServer(unittest.TestCase, CommonTests):
         ev = opcua.common.event.get_event_from_node(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.BaseEventType)))
         check_base_event(self, ev)
 
+    def test_create_custom_event(self):
+        event = self.opc.create_custom_event(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('PropertyNum', ua.VariantType.Float), ('PropertyString', ua.VariantType.String)])
+
+        base = opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.BaseEventType))
+        self.assertTrue(event in base.get_children())
+        nodes = event.get_referenced_nodes(refs=ua.ObjectIds.HasSubtype, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertEqual(base, nodes[0])
+        properties = event.get_properties()
+        self.assertIsNot(properties, None)
+
+
     def test_get_event_from_node_CustomEvent(self):
         ev = opcua.common.event.get_event_from_node(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.AuditEventType)))
         check_base_event(self, ev)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -228,7 +228,7 @@ class TestServer(unittest.TestCase, CommonTests):
         o = objects.add_object(3, 'MyObject')
         evgen = self.opc.get_event_generator(source=o)
         check_eventgenerator_BaseEvent(self, evgen)
-        self.assertEqual(evgen.event.SourceName, 'MyObject')
+        self.assertEqual(evgen.event.SourceName, b'MyObject')
         self.assertEqual(evgen.event.SourceNode, o.nodeid)
         self.assertEqual(o.get_attribute(ua.AttributeIds.EventNotifier).Value, ua.Variant(1, ua.VariantType.Byte))
 
@@ -238,7 +238,7 @@ class TestServer(unittest.TestCase, CommonTests):
         event = ua.BaseEvent(sourcenode=o.nodeid)
         evgen = self.opc.get_event_generator(event, ua.ObjectIds.Server)
         check_eventgenerator_BaseEvent(self, evgen)
-        self.assertEqual(evgen.event.SourceName, 'MyObject')
+        self.assertEqual(evgen.event.SourceName, b'MyObject')
         self.assertEqual(evgen.event.SourceNode, o.nodeid)
         self.assertEqual(o.get_attribute(ua.AttributeIds.EventNotifier).Value, ua.Variant(1, ua.VariantType.Byte))
 
@@ -313,7 +313,7 @@ class TestServer(unittest.TestCase, CommonTests):
 
         evgen = self.opc.get_event_generator(etype, o)
         check_eventgenerator_CustomEvent(self, evgen, etype)
-        self.assertEqual(evgen.event.SourceName, 'MyObject')
+        self.assertEqual(evgen.event.SourceName, b'MyObject')
         self.assertEqual(evgen.event.SourceNode, o.nodeid)
         self.assertEqual(o.get_attribute(ua.AttributeIds.EventNotifier).Value, ua.Variant(1, ua.VariantType.Byte))
 

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -1,8 +1,9 @@
 import unittest
-from tests_common import CommonTests, add_server_methods
+from tests_common import CommonTests, add_server_methods, MySubHandler
 import time
 from datetime import timedelta
 
+import opcua
 from opcua import Server
 from opcua import Client
 from opcua import ua
@@ -50,7 +51,7 @@ class TestServer(unittest.TestCase, CommonTests):
             self.assertTrue(new_app_uri in [s.ApplicationUri for s in new_servers])
         finally:
             client.disconnect()
-    
+
     def test_find_servers2(self):
         client = Client(self.discovery.endpoint.geturl())
         client.connect()
@@ -136,5 +137,112 @@ class TestServer(unittest.TestCase, CommonTests):
         var.set_value(3.0)
         self.srv.iserver.disable_history(var)
 
+    # This should work for following BaseEvent tests to work (maybe to write it a bit differentlly since they are not independent)
+    def test_get_event_from_node_BaseEvent(self):
+        ev = opcua.common.event.get_event_from_node(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.BaseEventType)))
+        check_base_event(self, ev)
+
+    def test_get_event_from_node_CustomEvent(self):
+        ev = opcua.common.event.get_event_from_node(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.AuditEventType)))
+        check_base_event(self, ev)
+
+    #def test_get_event_from_node_InheritanceEvent(self):
+        #ev = opcua.common.event.get_event_from_node(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.AuditEventType)))
+        #self.assertIsNot(ev, None)  # we did not receive event
+        #self.assertIsInstance(ev, ua.BaseEvent)
+        #self.assertIsInstance(ev, ua.AuditEventType)
+        #self.assertEqual(ev.EventType, ua.NodeId(ua.ObjectIds.AuditEventType))
+        #self.assertEqual(ev.SourceNode, ua.NodeId(ua.ObjectIds.Server))
+        #self.assertEqual(ev.Severity, ua.Variant(1, ua.VariantType.UInt16))
+        #self.assertEqual(ev._freeze, True)
+
+    def test_eventgenerator_default(self):
+        evgen = self.opc.get_event_generator()
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_BaseEvent_object(self):
+        evgen = self.opc.get_event_generator(ua.BaseEvent())
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_BaseEvent_Node(self):
+        evgen = self.opc.get_event_generator(opcua.Node(self.opc.iserver.isession, ua.NodeId(ua.ObjectIds.BaseEventType)))
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_BaseEvent_NodeId(self):
+        evgen = self.opc.get_event_generator(ua.NodeId(ua.ObjectIds.BaseEventType))
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_BaseEvent_ObjectIds(self):
+        evgen = self.opc.get_event_generator(ua.ObjectIds.BaseEventType)
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_BaseEvent_Identifier(self):
+        evgen = self.opc.get_event_generator(2041)
+        check_eventgenerator_BaseEvent(self, evgen)
+
+    def test_eventgenerator_sourceServer_Node(self):
+        pass
+
+    def test_eventgenerator_sourceServer_NodeId(self):
+        pass
+
+    def test_eventgenerator_sourceServer_ObjectIds(self):
+        pass
+
+    def test_eventgenerator_CustomEvent_object(self):
+        pass
+
+    def test_eventgenerator_CustomEvent_Node(self):
+        pass
+
+    def test_eventgenerator_CustomEvent_NodeId(self):
+        pass
+
+    def test_eventgenerator_CustomEvent_ObjectIds(self):
+        pass
+
+    #def test_eventgenerator_InheritedEvent(self):
+        #pass
 
 
+
+    #def test_events_default(self):
+        #msclt = MySubHandler()
+        #sub = self.opc.create_subscription(100, msclt)
+        #handle = sub.subscribe_events()
+
+        #ev = EventGenerator(self.srv.iserver.isession)
+        #msg = b"this is my msg "
+        #ev.Message.Text = msg
+        #tid = datetime.utcnow()
+        #ev.Time = tid
+        #ev.Severity = 500
+        #ev.trigger()
+
+        #ev = msclt.future.result()
+        #self.assertIsNot(ev, None)  # we did not receive event
+        #self.assertEqual(ev.SourceNode, self.opc.get_server_node().nodeid)
+        #self.assertEqual(ev.Message.Text, msg)
+        ##self.assertEqual(msclt.ev.Time, tid)
+        #self.assertEqual(ev.Severity, 500)
+
+        ## time.sleep(0.1)
+        #sub.unsubscribe(handle)
+        #sub.delete()
+
+
+def check_eventgenerator_BaseEvent(test, evgen):
+    test.assertIsNot(evgen, None)  # we did not receive event generator
+    test.assertIs(evgen.isession, test.opc.iserver.isession)
+    check_base_event(test, evgen.event)
+    test.assertEqual(evgen.event.SourceName, test.opc.get_server_node().get_display_name().Text)
+    test.assertEqual(test.opc.get_server_node().get_attribute(ua.AttributeIds.EventNotifier).Value, ua.Variant(1, ua.VariantType.Byte))
+
+
+def check_base_event(test, ev):
+    test.assertIsNot(ev, None)  # we did not receive event
+    test.assertIsInstance(ev, ua.BaseEvent)
+    test.assertEqual(ev.EventType, ua.NodeId(ua.ObjectIds.BaseEventType))
+    test.assertEqual(ev.SourceNode, ua.NodeId(ua.ObjectIds.Server))
+    test.assertEqual(ev.Severity, ua.Variant(1, ua.VariantType.UInt16))
+    test.assertEqual(ev._freeze, True)


### PR DESCRIPTION
Follwing the discussion in #133 and #159 I created new proposal, which is mix of original implementation and objects based implementation. @oroulet please give your opinion on following since I am starting to doubt on my object based idea (I generates additional code which is maybe not important at all. (This is just proposal so the test will probably not pass)

1. Object based proposal:
Object based proposal provides to freeze standard event types and better control over automatic filling of fields. We could implement an OPCUA-Object which takes care that every one of the UA objects (standard or custom) are provided into address space (something for #159).

@oroulet: Is this important in your opinion, does object based proposal provides some added value?

2. Generator-only based proposal:
The events and objects are generated from addresspace. The fields are automatically filed based on ObjectIds. We have Less code and very high flexibility. Users can potentially change standard event types unintentionally.

@oroulet: This is your original implementation

I will change this proposal according to the choice we make and provide first working version (at least for BaseEventType)
