### PR TITLE
Fix: Use daemon threads which will stop after other threads finished

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -34,6 +34,7 @@ class KeepAlive(Thread):
         if timeout == 0:  # means no timeout bu we do not trust such servers
             timeout = 360000
         self.timeout = timeout
+        self.daemon = True
         self.client = client
         self._dostop = False
         self._cond = Condition()

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -37,6 +37,7 @@ class UASocketClient(object):
         should not be necessary to call directly
         """
         self._thread = Thread(target=self._run)
+        self._thread.daemon = True
         self._thread.start()
 
     def _send_request(self, request, callback=None, timeout=1000, message_type=ua.MessageType.SecureMessage):

--- a/opcua/common/utils.py
+++ b/opcua/common/utils.py
@@ -125,6 +125,7 @@ class ThreadLoop(threading.Thread):
     def __init__(self):
         threading.Thread.__init__(self)
         self.logger = logging.getLogger(__name__)
+        self.daemon = True
         self.loop = None
         self._cond = threading.Condition()
 


### PR DESCRIPTION
Why?
Because this way, even if there is a programming error, the python process will finally exit. Otherwise, you have to kill it on purpose. 
Furthermore, one has to think about how to handle the client, keep it running and finally maybe exit it.

Contra?
Session.Close() will not be called, but that is also the case for the forced exit.