### PR TITLE
Added support for Inverse references

### DIFF
--- a/opcua/common/node.py
+++ b/opcua/common/node.py
@@ -242,7 +242,6 @@ class Node(object):
         HasNotifier = 48
         HasOrderedComponent = 49
         """
-        #references = self.get_children_descriptions(refs, nodeclassmask)
         return self.get_referenced_nodes(refs, ua.BrowseDirection.Forward, nodeclassmask)
 
     def get_properties(self):

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -108,7 +108,8 @@ class ViewService(object):
         """
         if ref1.Identifier == ref2.Identifier:
             return True
-        elif not subtypes or ref2.Identifier == ua.ObjectIds.HasSubtype:
+        #TODO: Please check the changes here
+        elif not subtypes:
             return False
         oktypes = self._get_sub_ref(ref1)
         return ref2 in oktypes
@@ -221,13 +222,15 @@ class NodeManagementService(object):
         self._aspace[nodedata.nodeid] = nodedata
 
         if not item.ParentNodeId.is_null():
-            addref = ua.AddReferencesItem()
-            addref.ReferenceTypeId = item.ReferenceTypeId
-            addref.SourceNodeId = item.ParentNodeId
-            addref.TargetNodeId = nodedata.nodeid
-            addref.TargetNodeClass = item.NodeClass
-            addref.IsForward = True
-            self._add_reference(addref, user)
+            desc = ua.ReferenceDescription()
+            desc.ReferenceTypeId = item.ReferenceTypeId
+            desc.NodeId = nodedata.nodeid
+            desc.NodeClass = item.NodeClass
+            desc.BrowseName = item.BrowseName
+            desc.DisplayName = ua.LocalizedText(item.BrowseName.Name)
+            desc.TypeDefinition = item.TypeDefinition
+            desc.IsForward = True
+            self._aspace[item.ParentNodeId].references.append(desc)
 
             addref = ua.AddReferencesItem()
             addref.ReferenceTypeId = item.ReferenceTypeId

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -86,7 +86,7 @@ class MySubHandler():
 
 class MySubHandler2():
     def __init__(self):
-        self.results = [] 
+        self.results = []
 
     def datachange_notification(self, node, val, data):
         self.results.append((node, val))
@@ -97,16 +97,14 @@ class MySubHandler2():
 
 class MySubHandlerCounter():
     def __init__(self):
-        self.datachange_count = 0 
-        self.event_count = 0 
+        self.datachange_count = 0
+        self.event_count = 0
 
     def datachange_notification(self, node, val, data):
         self.datachange_count += 1
 
     def event_notification(self, event):
         self.event_count += 1
-
-
 
 
 class CommonTests(object):
@@ -223,13 +221,41 @@ class CommonTests(object):
         self.assertTrue(prop2 in props)
         self.assertFalse(var in props)
         self.assertFalse(folder in props)
+        self.assertFalse(obj2 in props)
         all_vars = obj.get_children(nodeclassmask=ua.NodeClass.Variable)
         self.assertTrue(prop in all_vars)
         self.assertTrue(var in all_vars)
+        self.assertFalse(folder in props)
+        self.assertFalse(obj2 in props)
         all_objs = obj.get_children(nodeclassmask=ua.NodeClass.Object)
         self.assertTrue(folder in all_objs)
         self.assertTrue(obj2 in all_objs)
         self.assertFalse(var in all_objs)
+
+    def test_browse_references(self):
+        objects = self.opc.get_objects_node()
+        folder = objects.add_folder(4, "folder")
+
+        childs = objects.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Forward, includesubtypes=False)
+        self.assertTrue(folder in childs)
+
+        childs = objects.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Both, includesubtypes=False)
+        self.assertTrue(folder in childs)
+
+        childs = objects.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertFalse(folder in childs)
+
+        parents = folder.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertTrue(objects in parents)
+
+        parents = folder.get_referenced_nodes(refs=ua.ObjectIds.HierarchicalReferences, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertFalse(objects in parents)
+
+        parents = folder.get_referenced_nodes(refs=ua.ObjectIds.HierarchicalReferences, direction=ua.BrowseDirection.Inverse, includesubtypes=True)
+        self.assertTrue(objects in parents)
+
+        parent = folder.get_parent()
+        self.assertEqual(parent, objects)
 
     def test_browsename_with_spaces(self):
         o = self.opc.get_objects_node()
@@ -387,7 +413,7 @@ class CommonTests(object):
     def test_utf8(self):
         objects = self.opc.get_objects_node()
         utf_string = "æøå@%&"
-        bn = ua.QualifiedName(utf_string, 3) 
+        bn = ua.QualifiedName(utf_string, 3)
         nid = ua.NodeId("æølå", 3)
         val = "æøå"
         v = objects.add_variable(nid, bn, val)
@@ -747,7 +773,7 @@ class CommonTests(object):
         o = self.opc.get_objects_node()
 
         # subscribe to a variable
-        startv1 = True 
+        startv1 = True
         v1 = o.add_variable(3, 'SubscriptionVariableBool', startv1)
         sub = self.opc.create_subscription(100, msclt)
         handle1 = sub.subscribe_data_change(v1)
@@ -777,9 +803,9 @@ class CommonTests(object):
         msclt = MySubHandler2()
         o = self.opc.get_objects_node()
 
-        startv1 = True 
+        startv1 = True
         v1 = o.add_variable(3, 'SubscriptionVariableMany1', startv1)
-        startv2 = [1.22, 1.65] 
+        startv2 = [1.22, 1.65]
         v2 = o.add_variable(3, 'SubscriptionVariableMany2', startv2)
 
         sub = self.opc.create_subscription(100, msclt)
@@ -787,7 +813,7 @@ class CommonTests(object):
 
         # Now check we get the start values
         nodes = [v1, v2]
-       
+
         count = 0
         while not len(msclt.results) > 1:
             count += 1
@@ -804,7 +830,7 @@ class CommonTests(object):
             else:
                 self.fail("Error node {} is neither {} nor {}".format(node, v1, v2))
 
-        sub.delete() 
+        sub.delete()
 
     def test_subscribe_server_time(self):
         msclt = MySubHandler()
@@ -856,14 +882,57 @@ class CommonTests(object):
     def test_add_nodes(self):
         objects = self.opc.get_objects_node()
         f = objects.add_folder(3, 'MyFolder')
+        child = objects.get_child("3:MyFolder")
+        self.assertEqual(child, f)
+        o = f.add_object(3, 'MyObject')
+        child = f.get_child("3:MyObject")
+        self.assertEqual(child, o)
         v = f.add_variable(3, 'MyVariable', 6)
+        child = f.get_child("3:MyVariable")
+        self.assertEqual(child, v)
         p = f.add_property(3, 'MyProperty', 10)
+        child = f.get_child("3:MyProperty")
+        self.assertEqual(child, p)
         childs = f.get_children()
+        self.assertTrue(o in childs)
         self.assertTrue(v in childs)
         self.assertTrue(p in childs)
+
+    def test_references_for_added_nodes(self):
+        objects = self.opc.get_objects_node()
+        o = objects.add_object(3, 'MyObject')
+        nodes = objects.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Forward, includesubtypes=False)
+        self.assertTrue(o in nodes)
+        nodes = o.get_referenced_nodes(refs=ua.ObjectIds.Organizes, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertTrue(objects in nodes)
+        self.assertEqual(o.get_parent(), objects)
+        self.assertEqual(o.get_type_definition(), ua.ObjectIds.BaseObjectType)
+
+        o2 = o.add_object(3, 'MySecondObject')
+        nodes = o.get_referenced_nodes(refs=ua.ObjectIds.HasComponent, direction=ua.BrowseDirection.Forward, includesubtypes=False)
+        self.assertTrue(o2 in nodes)
+        nodes = o2.get_referenced_nodes(refs=ua.ObjectIds.HasComponent, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertTrue(o in nodes)
+        self.assertEqual(o2.get_parent(), o)
+        self.assertEqual(o2.get_type_definition(), ua.ObjectIds.BaseObjectType)
+
+        v = o.add_variable(3, 'MyVariable', 6)
+        nodes = o.get_referenced_nodes(refs=ua.ObjectIds.HasComponent, direction=ua.BrowseDirection.Forward, includesubtypes=False)
+        self.assertTrue(v in nodes)
+        nodes = v.get_referenced_nodes(refs=ua.ObjectIds.HasComponent, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertTrue(o in nodes)
+        self.assertEqual(v.get_parent(), o)
+        self.assertEqual(v.get_type_definition(), ua.ObjectIds.BaseDataVariableType)
+
+        p = o.add_property(3, 'MyProperty', 2)
+        nodes = o.get_referenced_nodes(refs=ua.ObjectIds.HasProperty, direction=ua.BrowseDirection.Forward, includesubtypes=False)
+        self.assertTrue(p in nodes)
+        nodes = p.get_referenced_nodes(refs=ua.ObjectIds.HasProperty, direction=ua.BrowseDirection.Inverse, includesubtypes=False)
+        self.assertTrue(o in nodes)
+        self.assertEqual(p.get_parent(), o)
+        self.assertEqual(p.get_type_definition(), ua.ObjectIds.PropertyType)
 
     def test_get_endpoints(self):
         endpoints = self.opc.get_endpoints()
         self.assertTrue(len(endpoints) > 0)
         self.assertTrue(endpoints[0].EndpointUrl.startswith("opc.tcp://"))
-


### PR DESCRIPTION
Working on #161 I found out that inverse references are missing (from child to parent). So here is initial implementation. The result is cross-compared with server based on Unified Automation SDK and Textual specification (Part 3) is consulted. Following major changes are done:

* Hierarchical references are automatically added (parent <--> child)
* create_method now returns Node (as all other create methods (variable, object))
* create_folder is now merged with create_object since the difference is in only one variable
* On multiple places are written constants instead of hard-coded numeric values
* Tests for references are written and some others are extended