### PR TITLE
Turn Client into a context manager

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -98,6 +98,13 @@ class Client(object):
         self._session_counter = 1
         self.keepalive = None
 
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self):
+        self.disconnect()
+
     @staticmethod
     def find_endpoint(endpoints, security_mode, policy_uri):
         """


### PR DESCRIPTION
Allows using client as a context manager for the with statement:

```
with Client(URL) as client:
    client.do_something()
```