### PR TITLE
New-style classes

### DIFF
--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -46,7 +46,7 @@ class SubHandler(object):
         pass
 
 
-class EventResult():
+class EventResult(object):
     """
     To be sent to clients for every events from server
     """
@@ -59,7 +59,7 @@ class EventResult():
     __repr__ = __str__
 
 
-class SubscriptionItemData():
+class SubscriptionItemData(object):
     """
     To store usefull data from a monitored item
     """
@@ -71,7 +71,7 @@ class SubscriptionItemData():
         self.mfilter = None
 
 
-class DataChangeNotif():
+class DataChangeNotif(object):
     """
     To be send to clients for every datachange notification from server
     """


### PR DESCRIPTION
Classes involved:
- EventResult
- SubscriptionItemData
- DataChangeNotif

Unless you are doing some hack that requires old-style classes, they should be new-style ones to ensure forward compatibility.