### PR TITLE
Correctly handle count parameter @ HistoryDict.save_node_value

### DIFF
--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -91,7 +91,7 @@ class HistoryDict(HistoryStorageInterface):
         data.append(datavalue)
         now = datetime.utcnow()
         if period:
-            while now - data[0].ServerTimestamp > period:
+            while len(data) and now - data[0].ServerTimestamp > period:
                 data.pop(0)
         if count and len(data) > count:
             data.pop(0)
@@ -214,12 +214,12 @@ class HistoryManager(object):
         since it requires more logic than other attribute service methods
         """
         results = []
-        
+
         for rv in params.NodesToRead:
             res = self._read_history(params.HistoryReadDetails, rv)
             results.append(res)
         return results
-        
+
     def _read_history(self, details, rv):
         """
         determine if the history read is for a data changes or events; then read the history for that node

--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -94,7 +94,7 @@ class HistoryDict(HistoryStorageInterface):
             while now - data[0].ServerTimestamp > period:
                 data.pop(0)
         if count and len(data) > count:
-            data = data[-count:]
+            data.pop(0)
 
     def read_node_history(self, node_id, start, end, nb_values):
         cont = None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,7 +17,7 @@ from tests_cmd_lines import TestCmdLines
 from tests_server import TestServer, TestServerCaching
 from tests_client import TestClient
 from tests_unit import TestUnit
-from tests_history import TestHistory
+from tests_history import TestHistory, TestHistorySQL, TestHistoryLimits, TestHistorySQLLimits
 from tests_history import TestHistorySQL
 if CRYPTOGRAPHY_AVAILABLE:
     from tests_crypto_connect import TestCryptoConnect

--- a/tests/tests_history.py
+++ b/tests/tests_history.py
@@ -40,7 +40,7 @@ class HistoryCommon(object):
         o = cls.srv.get_objects_node()
         cls.values = [i for i in range(20)]
         cls.var = o.add_variable(3, "history_var", 0)
-        cls.srv.iserver.enable_history_data_change(cls.var, period=None, count=10)
+        cls.srv.iserver.enable_history_data_change(cls.var, period=None, count=0)
         for i in cls.values:
             cls.var.set_value(i)
         time.sleep(1)


### PR DESCRIPTION
The current implementation is actually a no-op since the data is truncated
correctly but not assigned back to self._datachanges.
Pop the first value instead since this function is called for every
datachange which means that not more than one value will every be removed
in a single call.