### PR TITLE
Make History Consistent with Events

### DIFF
--- a/examples/server-datavalue-history.py
+++ b/examples/server-datavalue-history.py
@@ -1,0 +1,47 @@
+import sys
+sys.path.insert(0, "..")
+import time
+import math
+
+
+from opcua import ua, Server
+from opcua.server.history_sql import HistorySQLite
+
+
+if __name__ == "__main__":
+
+    # setup our server
+    server = Server()
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/freeopcua/server/")
+
+    # setup our own namespace, not really necessary but should as spec
+    uri = "http://examples.freeopcua.github.io"
+    idx = server.register_namespace(uri)
+
+    # get Objects node, this is where we should put our custom stuff
+    objects = server.get_objects_node()
+
+    # populating our address space
+    myobj = objects.add_object(idx, "MyObject")
+    myvar = myobj.add_variable(idx, "MyVariable", ua.Variant(0, ua.VariantType.Double))
+    myvar.set_writable()  # Set MyVariable to be writable by clients
+
+    # Configure server to use sqlite as history database (default is a simple in memory dict)
+    server.iserver.history_manager.set_storage(HistorySQLite("my_datavalue_history.sql"))
+
+    # starting!
+    server.start()
+
+    # enable data change history for this particular node, must be called after start since it uses subscription
+    server.iserver.enable_history_data_change(myvar, period=None, count=100)
+
+    try:
+        count = 0
+        while True:
+            time.sleep(1)
+            count += 0.1
+            myvar.set_value(math.sin(count))
+
+    finally:
+        # close connection, remove subscriptions, etc
+        server.stop()

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -183,24 +183,12 @@ class Subscription(object):
         sourcenode = Node(self.server, sourcenode)
 
         if evfilter is None:
-            # FIXME Review this, the commented out way doesn't support evtypes being passed a Node object
-            # if not type(evtypes) in (list, tuple):
-            #     evtypes = [evtypes]
-            #
-            # evtypes = [Node(self.server, i) for i in evtypes]  # make sure we have a list of Node objects
-
             if not type(evtypes) in (list, tuple):
                 evtypes = [evtypes]
 
-            # FIXME not a very nice way to make sure events.get_filter gets a list of nodes...
-            evtype_nodes = []
-            for evtype in evtypes:
-                if not isinstance(evtype, Node):
-                    evtype_nodes.append(Node(self.server, ua.NodeId(evtype)))  # make sure we have a list of Node objects
-                else:
-                    evtype_nodes.append(evtype)
+            evtypes = [Node(self.server, evtype) for evtype in evtypes]
 
-            evfilter = events.get_filter_from_event_type(evtype_nodes)
+            evfilter = events.get_filter_from_event_type(evtypes)
         return self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter)
 
     def _subscribe(self, nodes, attr, mfilter=None, queuesize=0):


### PR DESCRIPTION
Remove some event FIXMEs from subscription and make it match node.py.

Minor changes and cleanup to make history module consistent with events. Mainly that historizing new events now takes a list of event type nodes. The module which implements the history interface is responsible for formatting the events types itself (for example converting event types to a list of fields like in SQL)

I also cleaned up history examples and added a new example for historizing data changes on a variable, since at some point that example code was lost during all the events stuff.