### PR TITLE
Support providing objecttype for the method add_object of Node

### DIFF
--- a/examples/customobject.xml
+++ b/examples/customobject.xml
@@ -1,0 +1,35 @@
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:s1="https://github.com/FreeOpcUa/python-opcua/customobject/Types.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>https://github.com/FreeOpcUa/python-opcua/customobject</Uri>
+    </NamespaceUris>
+    <Aliases>
+        <Alias Alias="Double">i=11</Alias>
+        <Alias Alias="HasModellingRule">i=37</Alias>
+        <Alias Alias="HasTypeDefinition">i=40</Alias>
+        <Alias Alias="HasSubtype">i=45</Alias>
+        <Alias Alias="HasComponent">i=47</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <ModelInfo Tool="UaModeler" Hash="qnoF+0+hDsL4GCM37vuINw==" Version="1.4.3"/>
+        </Extension>
+    </Extensions>
+    <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:MyObjectType">
+        <DisplayName>MyObjectType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasComponent">ns=1;i=6001</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+        </References>
+    </UAObjectType>
+    <UAVariable DataType="Double" ParentNodeId="ns=1;i=1002" NodeId="ns=1;i=6001" BrowseName="1:MyVariable" UserAccessLevel="3" AccessLevel="3">
+        <DisplayName>MyVariable</DisplayName>
+        <References>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1002</Reference>
+        </References>
+        <Value>
+            <uax:Double>0</uax:Double>
+        </Value>
+    </UAVariable>
+</UANodeSet>

--- a/examples/server-customobject.py
+++ b/examples/server-customobject.py
@@ -1,0 +1,52 @@
+import sys
+sys.path.insert(0, "..")
+import time
+
+
+from opcua import ua, Server
+
+
+if __name__ == "__main__":
+
+    # setup our server
+    server = Server()
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/freeopcua/server/")
+
+    # setup our own namespace, not really necessary but should as spec
+    uri = "http://examples.freeopcua.github.io"
+    idx = server.register_namespace(uri)
+
+    # Import customobject type
+    server.import_xml('customobject.xml')
+
+    # get Objects node, this is where we should put our custom stuff
+    objects = server.get_objects_node()
+
+
+    # get nodeid of custom object type by :
+    # 1) Use node ID
+    # 2) Or Full path
+    # 3) Or As child from parent
+    nodeid_a = ua.NodeId.from_string('ns=1;i=1002')
+    nodeid_b = server.get_root_node().get_child(["0:Types", "0:ObjectTypes", "0:BaseObjectType", "1:MyObjectType"]).nodeid
+    nodeid_c = server.get_node(ua.ObjectIds.BaseObjectType).get_child(["1:MyObjectType"]).nodeid
+
+
+    myobject_type_nodeid = nodeid_a
+
+    # populating our address space
+    myobj = objects.add_object(idx, "MyObject",)
+    myobj = objects.add_object(idx, "MyCustomObject", myobject_type_nodeid)
+
+    # starting!
+    server.start()
+
+    try:
+        count = 0
+        while True:
+            time.sleep(1)
+            count += 0.1
+            myvar.set_value(count)
+    finally:
+        # close connection, remove subcsriptions, etc
+        server.stop()


### PR DESCRIPTION
The Node.add_object let you only create object of the type BaseObjectType. It would be nice if you also could create other types by providing an objecttype.

Like:
myobj = objects.add_object(idx, "MyCustomObject", myobjectype_nodeid)

The only thing this patch do is setting the correct NodeId in the TypeDefinition.