### PR TITLE
xmlimport breaks when UAVariable doesn't have value element

### DIFF
--- a/examples/server-customobject.py
+++ b/examples/server-customobject.py
@@ -42,11 +42,8 @@ if __name__ == "__main__":
     server.start()
 
     try:
-        count = 0
         while True:
             time.sleep(1)
-            count += 0.1
-            myvar.set_value(count)
     finally:
         # close connection, remove subcsriptions, etc
         server.stop()

--- a/opcua/common/manage_nodes.py
+++ b/opcua/common/manage_nodes.py
@@ -59,7 +59,6 @@ def create_object(parent, *args):
                 objecttype = ua.NodeId.from_string(objecttype)
             else:
                 raise RuntimeError()
-            return nodeid, qname
         except ua.UaError:
             raise
         except Exception as ex:

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -27,7 +27,7 @@ class NodeData(object):
         # variable
         self.datatype = None
         self.rank = -1  # check default value
-        self.value = []
+        self.value = None
         self.valuetype = None
         self.dimensions = None
         self.accesslevel = None

--- a/tests/custom_nodes.xml
+++ b/tests/custom_nodes.xml
@@ -39,5 +39,12 @@
     </Value>
   </UAVariable>
 
+  <UAVariable NodeId="i=30004" BrowseName="MyXMLVariableWithoutValue" DataType="String">
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+    </References>
+  </UAVariable>
+
 
 </UANodeSet>

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -479,6 +479,26 @@ class CommonTests(object):
         self.assertTrue(v in childs)
         self.assertTrue(p in childs)
 
+    def test_add_node_withtype(self):		
+        objects = self.opc.get_objects_node()
+        f = objects.add_folder(3, 'MyFolder')
+
+        o = f.add_object(3, 'MyObject1', ua.ObjectIds.BaseObjectType)
+        self.assertEqual(o.get_type_definition(), ua.ObjectIds.BaseObjectType)
+
+        o = f.add_object(3, 'MyObject2', ua.NodeId(ua.ObjectIds.BaseObjectType, 0) )
+        self.assertEqual(o.get_type_definition(), ua.ObjectIds.BaseObjectType)
+        
+        base_otype= self.opc.get_node(ua.ObjectIds.BaseObjectType)
+        custom_otype = base_otype.add_subtype(2, 'MyFooObjectType')
+
+        o = f.add_object(3, 'MyObject3', custom_otype.nodeid )
+        self.assertEqual(o.get_type_definition(), custom_otype.nodeid.Identifier)
+                
+        references = o.get_references(refs=ua.ObjectIds.HasTypeDefinition, direction=ua.BrowseDirection.Forward)
+        self.assertEqual(len(references), 1)        
+        self.assertEqual(references[0].NodeId, custom_otype.nodeid)
+                
     def test_references_for_added_nodes(self):
         objects = self.opc.get_objects_node()
         o = objects.add_object(3, 'MyObject')

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -481,7 +481,7 @@ class CommonTests(object):
 
     def test_add_node_withtype(self):		
         objects = self.opc.get_objects_node()
-        f = objects.add_folder(3, 'MyFolder')
+        f = objects.add_folder(3, 'MyFolder_TypeTest')
 
         o = f.add_object(3, 'MyObject1', ua.ObjectIds.BaseObjectType)
         self.assertEqual(o.get_type_definition(), ua.ObjectIds.BaseObjectType)
@@ -498,7 +498,7 @@ class CommonTests(object):
         references = o.get_references(refs=ua.ObjectIds.HasTypeDefinition, direction=ua.BrowseDirection.Forward)
         self.assertEqual(len(references), 1)        
         self.assertEqual(references[0].NodeId, custom_otype.nodeid)
-                
+                        
     def test_references_for_added_nodes(self):
         objects = self.opc.get_objects_node()
         o = objects.add_object(3, 'MyObject')


### PR DESCRIPTION
The fragment below breaks then XmlImporter:
```xml
<UAVariable NodeId="i=30004" BrowseName="MyXMLVariableWithoutValue" DataType="String">
    <References>
         <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
         <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
    </References>
 </UAVariable>
```

The import doesn't break if an value element is present. According to the OPC UA schema it is allowed to don't have a value element ( see https://opcfoundation.org/UA/schemas/1.02/UANodeSet.xsd).

The error is due a small typo in XmlParser.__init__ :
```python
  self.value = [] # should be None instead
```
The default value of a value is set to [], while at XmlImporter.add_variable it is checked to unequal to None:
```python
  if obj.value is not None:
```
 Set the default value to None fixes the issue.

Test data of the testcase TestServer.test_xml_import is updated to test this situation.