### PR TITLE
xmlimport breaks when UAVariable doesn't have value element (2)

### DIFF
--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -27,7 +27,7 @@ class NodeData(object):
         # variable
         self.datatype = None
         self.rank = -1  # check default value
-        self.value = []
+        self.value = None
         self.valuetype = None
         self.dimensions = None
         self.accesslevel = None

--- a/tests/custom_nodes.xml
+++ b/tests/custom_nodes.xml
@@ -39,5 +39,12 @@
     </Value>
   </UAVariable>
 
+  <UAVariable NodeId="i=30004" BrowseName="MyXMLVariableWithoutValue" DataType="String">
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+    </References>
+  </UAVariable>
+
 
 </UANodeSet>


### PR DESCRIPTION
The fragment below breaks then XmlImporter:
```xml
<UAVariable NodeId="i=30004" BrowseName="MyXMLVariableWithoutValue" DataType="String">
    <References>
         <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
         <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
    </References>
 </UAVariable>
```

The import doesn't break if an value element is present. According to the OPC UA schema it is allowed to don't have a value element ( see https://opcfoundation.org/UA/schemas/1.02/UANodeSet.xsd).

The error is due a small typo in XmlParser.__init__ :
```python
  self.value = [] # should be None instead
```
The default value of a value is set to [], while at XmlImporter.add_variable it is checked to unequal to None:
```python
  if obj.value is not None:
```
 Set the default value to None fixes the issue.

Test data of the testcase TestServer.test_xml_import is updated to test this situation.