### PR TITLE
Support xml address space import with custom data types

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -45,28 +45,25 @@ class XmlImporter(object):
         if obj.parent:
             node.ParentNodeId = ua.NodeId.from_string(obj.parent)
         if obj.parentlink:
-            node.ReferenceTypeId = self.to_ref_type(obj.parentlink)
+            node.ReferenceTypeId = self.to_nodeid(obj.parentlink)
         if obj.typedef:
             node.TypeDefinition = ua.NodeId.from_string(obj.typedef)
         return node
 
-    def to_data_type(self, nodeid):
+    def to_nodeid(self, nodeid):
         if not nodeid:
             return ua.NodeId(ua.ObjectIds.String)
-        if "=" in nodeid:
+        elif "=" in nodeid:
             return ua.NodeId.from_string(nodeid)
-        else:
+        elif hasattr(ua.ObjectIds, nodeid):
             return ua.NodeId(getattr(ua.ObjectIds, nodeid))
-
-    def to_ref_type(self, nodeid):
-        if "=" not in nodeid:
+        else:
             if nodeid in self.parser.aliases:
                 nodeid = self.parser.aliases[nodeid]
             else:
                 nodeid = "i={}".format(getattr(ua.ObjectIds, nodeid))
-
-        return ua.NodeId.from_string(nodeid)
-
+            return ua.NodeId.from_string(nodeid)                
+        
     def add_object(self, obj):
         node = self._get_node(obj)
         attrs = ua.ObjectAttributes()
@@ -95,7 +92,7 @@ class XmlImporter(object):
         if obj.desc:
             attrs.Description = ua.LocalizedText(obj.desc)
         attrs.DisplayName = ua.LocalizedText(obj.displayname)
-        attrs.DataType = self.to_data_type(obj.datatype)
+        attrs.DataType = self.to_nodeid(obj.datatype)
         # if obj.value and len(obj.value) == 1:
         if obj.value is not None:
             attrs.Value = ua.Variant(obj.value, getattr(ua.VariantType, obj.valuetype))
@@ -119,7 +116,7 @@ class XmlImporter(object):
         if obj.desc:
             attrs.Description = ua.LocalizedText(obj.desc)
         attrs.DisplayName = ua.LocalizedText(obj.displayname)
-        attrs.DataType = self.to_data_type(obj.datatype)
+        attrs.DataType = self.to_nodeid(obj.datatype)
         if obj.value and len(obj.value) == 1:
             attrs.Value = obj.value[0]
         if obj.rank:
@@ -185,7 +182,7 @@ class XmlImporter(object):
         for data in obj.refs:
             ref = ua.AddReferencesItem()
             ref.IsForward = True
-            ref.ReferenceTypeId = self.to_ref_type(data.reftype)
+            ref.ReferenceTypeId = self.to_nodeid(data.reftype)
             ref.SourceNodeId = ua.NodeId.from_string(obj.nodeid)
             ref.TargetNodeClass = ua.NodeClass.DataType
             ref.TargetNodeId = ua.NodeId.from_string(data.target)

--- a/tests/custom_nodes.xml
+++ b/tests/custom_nodes.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.02" LastModified="2013-03-06T05:36:44.0862658Z" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <Aliases>
+     <Alias Alias="MyCustomString">ns=1;i=3008</Alias>
+  </Aliases>
 
   <UAObject NodeId="i=30001" BrowseName="MyXMLFolder"  >
     <Description>A custom folder.</Description>
@@ -39,12 +42,24 @@
     </Value>
   </UAVariable>
 
-  <UAVariable NodeId="i=30004" BrowseName="MyXMLVariableWithoutValue" DataType="String">
+  <UAVariable NodeId="i=30006" BrowseName="MyXMLVariableWithoutValue" DataType="String">
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
       <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
     </References>
   </UAVariable>
-
-
+  
+  <UADataType NodeId="ns=1;i=3008" BrowseName="1:MyCustomString">
+    <DisplayName>MyCustomString</DisplayName>
+      <References>
+          <Reference ReferenceType="HasSubtype" IsForward="false">i=12</Reference>
+    </References>
+  </UADataType>
+	
+  <UAVariable NodeId="i=30007" BrowseName="MyCustomTypeVar" DataType="MyCustomString">
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+    </References>
+  </UAVariable>
 </UANodeSet>


### PR DESCRIPTION
Support custom data types with the XmlImporter. The datatype can be base on:

- Type based on string version of nodeid
`<UAVariable DataType="ns=1;i=3004" ParentNodeId="ns=1;i=5002" NodeId="ns=1;i=6006" BrowseName="1:MyVar">`

- Type based on ua ojectids
`<UAVariable DataType="String" ParentNodeId="ns=1;i=5002" NodeId="ns=1;i=6006" BrowseName="1:MyVar">`

- Typed based on alias
`<UAVariable DataType="MyVarType" ParentNodeId="ns=1;i=5002" NodeId="ns=1;i=6006" BrowseName="1:MyVar">`

custom_nodes.xml is updated to let TestServer:test_xml_import verify the change.
