### PR TITLE
fix __exit__ method of client and server class

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -102,7 +102,7 @@ class Client(object):
         self.connect()
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.disconnect()
 
     @staticmethod

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -94,7 +94,7 @@ class Server(object):
         self.start()
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.stop()
 
     def load_certificate(self, path):

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -82,4 +82,21 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests):
             v_ro.set_value(9)
         self.assertEqual(v_ro.get_value(), 2)
 
+    def test_context_manager(self):
+        """ Context manager calls connect() and disconnect()
+        """
+        state = [0]
+        def increment_state(self, *args, **kwargs):
+            state[0] += 1
 
+        # create client and replace instance methods with dummy methods
+        client = Client('opc.tcp://dummy_address:10000')
+        client.connect    = increment_state.__get__(client)
+        client.disconnect = increment_state.__get__(client)
+
+        assert state[0] == 0
+        with client:
+            # test if client connected
+            self.assertEqual(state[0], 1)
+        # test if client disconnected
+        self.assertEqual(state[0], 2)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -339,6 +339,24 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests):
         tp2 = v2.get_data_type()
         self.assertEqual( ua.NodeId(ua.ObjectIds.ApplicationType), tp2)         
 
+    def test_context_manager(self):
+        """ Context manager calls start() and stop()
+        """
+        state = [0]
+        def increment_state(self, *args, **kwargs):
+            state[0] += 1
+
+        # create server and replace instance methods with dummy methods
+        server = Server()
+        server.start = increment_state.__get__(server)
+        server.stop  = increment_state.__get__(server)
+
+        assert state[0] == 0
+        with server:
+            # test if server started
+            self.assertEqual(state[0], 1)
+        # test if server stopped
+        self.assertEqual(state[0], 2)
 
 def check_eventgenerator_SourceServer(test, evgen):
     server = test.opc.get_server_node()


### PR DESCRIPTION
This seems to have been implemented without testing. As far as I can tell this never worked.

Context managers work the same way since Python 2.5 when they were introduced: https://docs.python.org/2.5/lib/typecontextmanager.html