### PR TITLE
[xmlimporter] support for values with EnumValues

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -62,8 +62,8 @@ class XmlImporter(object):
                 nodeid = self.parser.aliases[nodeid]
             else:
                 nodeid = "i={}".format(getattr(ua.ObjectIds, nodeid))
-            return ua.NodeId.from_string(nodeid)                
-        
+            return ua.NodeId.from_string(nodeid)
+
     def add_object(self, obj):
         node = self._get_node(obj)
         attrs = ua.ObjectAttributes()
@@ -95,8 +95,18 @@ class XmlImporter(object):
         attrs.DataType = self.to_nodeid(obj.datatype)
         # if obj.value and len(obj.value) == 1:
         if obj.value is not None:
+            #TODO: If non variant based types grow move it to a seperate function 
             if obj.valuetype == 'ListOfLocalizedText':
                 attrs.Value = ua.Variant([ua.LocalizedText(txt) for txt in obj.value], None)
+            elif obj.valuetype == 'EnumValueType':
+                values = []
+                for ev in obj.value:
+                    enum_value = ua.EnumValueType()
+                    enum_value.DisplayName = ua.LocalizedText(ev['DisplayName'])
+                    enum_value.Description = ua.LocalizedText(ev['Description'])
+                    enum_value.Value = int(ev['Value'])
+                    values.append(enum_value)
+                attrs.Value = values
             else:
                 attrs.Value = ua.Variant(obj.value, getattr(ua.VariantType, obj.valuetype))
         if obj.rank:

--- a/tests/custom_nodes.xml
+++ b/tests/custom_nodes.xml
@@ -8,6 +8,7 @@
      <Alias Alias="HasProperty">i=46</Alias>
      <Alias Alias="MyCustomString">ns=1;i=3008</Alias>
      <Alias Alias="MyEnum">ns=1;i=3010</Alias>
+     <Alias Alias="MyEnumVal">ns=1;i=3011</Alias>
   </Aliases>
 
   <UAObject NodeId="i=30001" BrowseName="MyXMLFolder"  >
@@ -70,6 +71,7 @@
     </References>
   </UAVariable>
   
+  <!-- test data Enumeration with EnumStrings -->
   <UADataType NodeId="ns=1;i=3010" BrowseName="1:MyEnum">
         <DisplayName>MyEnum</DisplayName>
         <Description>Demonstrates enums</Description>
@@ -104,6 +106,75 @@
                 </uax:LocalizedText>
             </uax:ListOfLocalizedText>
         </Value>
-    </UAVariable>
+  </UAVariable>
+  
+  <!-- test data Enumeration with EnumValues -->  
+  <UADataType NodeId="ns=1;i=3011" BrowseName="1:MyEnumVal">
+        <DisplayName>MyEnumVal</DisplayName>
+        <References>
+            <Reference ReferenceType="HasProperty">ns=1;i=6002</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=29</Reference>
+        </References>
+        <Definition Name="1:MyEnumVal">
+            <Field Name="idle" Value="1"/>
+            <Field Name="run" Value="2"/>
+            <Field Name="error" Value="4"/>
+        </Definition>
+  </UADataType>
+  
+  <UAVariable DataType="EnumValueType" ParentNodeId="ns=1;i=3011" ValueRank="1" NodeId="ns=1;i=6002" ArrayDimensions="3" BrowseName="EnumValues">
+        <DisplayName>EnumValues</DisplayName>
+        <References>
+            <Reference ReferenceType="HasModellingRule">i=78</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=3011</Reference>
+        </References>
+        <Value>
+            <uax:ListOfExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=7616</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:EnumValueType>
+                            <uax:Value>1</uax:Value>
+                            <uax:DisplayName>
+                                <uax:Text>idle</uax:Text>
+                            </uax:DisplayName>
+                            <uax:Description/>
+                        </uax:EnumValueType>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=7616</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:EnumValueType>
+                            <uax:Value>2</uax:Value>
+                            <uax:DisplayName>
+                                <uax:Text>run</uax:Text>
+                            </uax:DisplayName>
+                            <uax:Description/>
+                        </uax:EnumValueType>
+                    </uax:Body>
+                </uax:ExtensionObject>
+                <uax:ExtensionObject>
+                    <uax:TypeId>
+                        <uax:Identifier>i=7616</uax:Identifier>
+                    </uax:TypeId>
+                    <uax:Body>
+                        <uax:EnumValueType>
+                            <uax:Value>4</uax:Value>
+                            <uax:DisplayName>
+                                <uax:Text>error</uax:Text>
+                            </uax:DisplayName>
+                            <uax:Description/>
+                        </uax:EnumValueType>
+                    </uax:Body>
+                </uax:ExtensionObject>
+            </uax:ListOfExtensionObject>
+        </Value>
+  </UAVariable>    
       
 </UANodeSet>

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -138,6 +138,9 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests):
         o = self.opc.get_root_node().get_child(["Types", "DataTypes", "BaseDataType", "Enumeration", "1:MyEnum", "0:EnumStrings"])
         self.assertEqual(len(o.get_value() ), 3)
 
+        o = self.opc.get_root_node().get_child(["Types", "DataTypes", "BaseDataType", "Enumeration", "1:MyEnumVal", "0:EnumValues"])
+        self.assertEqual(len(o.get_value() ), 3)
+
         
     def test_historize_variable(self):
         o = self.opc.get_objects_node()


### PR DESCRIPTION
Added loading of EnumValues ( listofextension oject ) to the xmlparser and xmlimport.

In combination with PR #238 python-opcua now fully supports importing Enumerations based on EnumString (ascending numbers) and EnumValues(numbers with gaps or bitmasks).

Example fragment ListOfExtensionObject of EnumValues:
```xml
    <Value>
            <uax:ListOfExtensionObject>
                <uax:ExtensionObject>
                    <uax:TypeId>
                        <uax:Identifier>i=7616</uax:Identifier>
                    </uax:TypeId>
                    <uax:Body>
                        <uax:EnumValueType>
                            <uax:Value>1</uax:Value>
                            <uax:DisplayName>
                                <uax:Text>idle</uax:Text>
                            </uax:DisplayName>
                            <uax:Description/>
                        </uax:EnumValueType>
                    </uax:Body>
                </uax:ExtensionObject>
                <uax:ExtensionObject>
                    <uax:TypeId>
                        <uax:Identifier>i=7616</uax:Identifier>
                    </uax:TypeId>
                    <uax:Body>
                        <uax:EnumValueType>
                            <uax:Value>2</uax:Value>
                            <uax:DisplayName>
                                <uax:Text>run</uax:Text>
                            </uax:DisplayName>
                            <uax:Description/>
                        </uax:EnumValueType>
                    </uax:Body>
                </uax:ExtensionObject>
            </uax:ListOfExtensionObject>
        </Value>
```