### PR TITLE
replace custom test disabling with unittest.skip

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,14 +3,6 @@ import logging
 import sys
 sys.path.insert(0, "..")
 sys.path.insert(0, ".")
-try:
-    from opcua.crypto import uacrypto
-    CRYPTOGRAPHY_AVAILABLE = True
-except ImportError:
-    print("WARNING: CRYPTO NOT AVAILABLE, CRYPTO TESTS DISABLED!!")
-    CRYPTOGRAPHY_AVAILABLE = False
-
-
 
 
 from tests_cmd_lines import TestCmdLines
@@ -19,8 +11,7 @@ from tests_client import TestClient
 from tests_unit import TestUnit
 from tests_history import TestHistory, TestHistorySQL, TestHistoryLimits, TestHistorySQLLimits
 from tests_history import TestHistorySQL
-if CRYPTOGRAPHY_AVAILABLE:
-    from tests_crypto_connect import TestCryptoConnect
+from tests_crypto_connect import TestCryptoConnect
 
 
 if __name__ == '__main__':

--- a/tests/tests_crypto_connect.py
+++ b/tests/tests_crypto_connect.py
@@ -3,12 +3,21 @@ import unittest
 from opcua import Client
 from opcua import Server
 from opcua import ua
-from opcua.crypto import security_policies
+
+try:
+    from opcua.crypto import uacrypto
+    from opcua.crypto import security_policies
+except ImportError:
+    print("WARNING: CRYPTO NOT AVAILABLE, CRYPTO TESTS DISABLED!!")
+    disable_crypto_tests = True
+else:
+    disable_crypto_tests = False
+
 
 port_num1 = 48515
 port_num2 = 48512
 
-
+@unittest.skipIf(disable_crypto_tests, "crypto not available")
 class TestCryptoConnect(unittest.TestCase):
 
     '''
@@ -112,8 +121,3 @@ class TestCryptoConnect(unittest.TestCase):
                              None,
                              ua.MessageSecurityMode.None_
                              )
-
-
-
-
-


### PR DESCRIPTION
Instead of using our own solution for skipping test, we use
unittest.skip. This has the additional benefit that it works
with the automatic test discovery in Python >=3.2.