### PR TITLE
Support importing Guid from XML

### DIFF
--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -268,6 +268,8 @@ class XMLParser(object):
                 mytext = mytext.replace('\n', '').replace('\r', '')
                 # obj.value.append('b"{}"'.format(mytext))
                 obj.value = mytext
+            elif ntag in ("Guid"):
+                self._parse_value(val, obj)
             elif ntag == "ListOfExtensionObject":
                 obj.value, obj.valuetype = self._parse_list_of_extension_object(el)
             elif ntag == "ListOfLocalizedText":


### PR DESCRIPTION
If node value is type Guid get the value from the child ```<string>``` tag.

Example XML to parse:
```xml
    <UAVariable DataType="Guid" ParentNodeId="ns=1;s=Machine0" NodeId="ns=1;s=Machine0.Id" BrowseName="1:Id">
        <DisplayName>Id</DisplayName>
        <References>
            <Reference ReferenceType="HasProperty" IsForward="false">ns=1;s=Machine0</Reference>
            <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
        </References>
        <Value>
            <uax:Guid>
                <uax:String>ead83ed2-7323-44ab-83ad-ed5d3be7bc2f</uax:String>
            </uax:Guid>
```