### PR TITLE
Add link_method to server

### DIFF
--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -416,3 +416,6 @@ class Server(object):
 
     def unsubscribe_server_callback(self, event, handle):
         self.iserver.unsubscribe_server_callback(event, handle)
+
+    def link_method(self, node, callback):
+        node.server.add_method_callback(node.nodeid, callback)

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -418,4 +418,4 @@ class Server(object):
         self.iserver.unsubscribe_server_callback(event, handle)
 
     def link_method(self, node, callback):
-        node.server.add_method_callback(node.nodeid, callback)
+        self.iserver.isession.add_method_callback(node.nodeid, callback)


### PR DESCRIPTION
shortcut to linking python functions to UA Method nodes, for example
after instantiating an object from object type which has a method.

To be used after instantiating from a custom type which has a method node.
See: #297 