### PR TITLE
Move nsrel to xmlimport

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -76,14 +76,10 @@ class XmlImporter(object):
         # The ordering of nodes currently only works if namespaces are
         # defined in XML.
         # Also, it is recommended not to use node ids without namespace prefix!
-
-        # FIX: _sort_nodes_by_parentid is broken needs fix before enabling
-        nodes_parsed = list(self.parser)
-        # nodes_parsed = self._sort_nodes_by_parentid(self.parser)
+        nodes_parsed = self._sort_nodes_by_parentid(self.parser)
 
         nodes = []
         for nodedata in nodes_parsed:  # self.parser:
-            print(nodedata.nodeid)
             if nodedata.nodetype == 'UAObject':
                 node = self.add_object(nodedata)
             elif nodedata.nodetype == 'UAObjectType':
@@ -376,7 +372,7 @@ class XmlImporter(object):
         # are defined in the xml file itself. Thus we assume that all other
         # references namespaces are already known to the server and should
         # not create any dependency problems (like "NodeNotFound")
-        relevant_namespaces = [str(i[0]) for i in self.namespaces.values()]
+        relevant_namespaces = [str(ns) for ns in self.namespaces.keys()]
         while len(_nodes) > 0:
             pop_nodes = []
             for node in _nodes:
@@ -384,11 +380,11 @@ class XmlImporter(object):
                 # Get the node and parent node namespace and id parts
                 node_ns, node_id = self._split_node_id(node.nodeid)
                 parent_ns, parent_id = self._split_node_id(node.parent)
-
                 # Insert nodes that
                 #   (1) have no parent / parent_ns is None (e.g. namespace 0)
                 #   (2) ns is not in list of relevant namespaces
-                if (parent_ns is None or node_ns not in relevant_namespaces or
+                if (parent_ns is None or
+                    (len(relevant_namespaces) >= 1 and node_ns not in relevant_namespaces) or
                     parent_id is None):
                     insert = 0
                 else:
@@ -396,7 +392,6 @@ class XmlImporter(object):
                     # inserted nodes
                     if node.parent in sorted_nodes_ids:
                         insert = -1
-
                 if insert == 0:
                     sorted_nodes.insert(insert, node)
                     sorted_nodes_ids.insert(insert, node.nodeid)

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -84,6 +84,18 @@ class XMLParser(object):
         self.namespaces = {}
         self._re_nodeid = re.compile(r"^ns=(?P<ns>\d+[^;]*);i=(?P<i>\d+)")
 
+    def get_used_namespaces(self):
+        """
+        Return the used namespace uris in this import file
+        """
+        namespaces_uris = []
+        for child in self.root:
+            name = self._retag.match(child.tag).groups()[1]
+            if name == 'NamespaceUris':
+                namespaces_uris = [ns_element.text for ns_element in child]
+                break
+        return namespaces_uris
+
     def __iter__(self):
         nodes = []
         for child in self.root:
@@ -92,6 +104,7 @@ class XMLParser(object):
                 for el in child:
                     self.aliases[el.attrib["Alias"]] = self._get_node_id(el.text)
             elif name == 'NamespaceUris':
+                print(child.tag)
                 for ns_index, ns_element in enumerate(child):
                     ns_uri = ns_element.text
                     ns_server_index = self.server.register_namespace(ns_uri)
@@ -233,7 +246,6 @@ class XMLParser(object):
     def _set_attr(self, key, val, obj):
         if key == "NodeId":
             obj.nodeid = self._get_node_id(val)
-            print("PARSING", obj.nodeid)
         elif key == "BrowseName":
             obj.browsename = self._parse_bname(val)
         elif key == "SymbolicName":

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -75,14 +75,10 @@ class XMLParser(object):
         self.logger = logging.getLogger(__name__)
         self._retag = re.compile(r"(\{.*\})(.*)")
         self.path = xmlpath
-        self.aliases = {}
 
         self.tree = ET.parse(xmlpath)
         self.root = self.tree.getroot()
         self.it = None
-
-        self.namespaces = {}
-        self._re_nodeid = re.compile(r"^ns=(?P<ns>\d+[^;]*);i=(?P<i>\d+)")
 
     def get_used_namespaces(self):
         """
@@ -96,29 +92,26 @@ class XMLParser(object):
                 break
         return namespaces_uris
 
+    def get_aliases(self):
+        """
+        Return the used node aliases in this import file
+        """
+        aliases = {}
+        for child in self.root:
+            name = self._retag.match(child.tag).groups()[1]
+            if name == 'Aliases':
+                for el in child:
+                    aliases[el.attrib["Alias"]] = el.text
+                break
+        return aliases
+
     def __iter__(self):
         nodes = []
         for child in self.root:
             name = self._retag.match(child.tag).groups()[1]
-            if name == "Aliases":
-                for el in child:
-                    self.aliases[el.attrib["Alias"]] = self._get_node_id(el.text)
-            elif name == 'NamespaceUris':
-                print(child.tag)
-                for ns_index, ns_element in enumerate(child):
-                    ns_uri = ns_element.text
-                    ns_server_index = self.server.register_namespace(ns_uri)
-                    self.namespaces[ns_index + 1] = (ns_server_index, ns_uri)
-                    print("namespace offset", ns_index + 1, (ns_server_index, ns_uri))
-            else:
+            if name not in ["Aliases", "NamespaceUris"]:
                 node = self._parse_node(name, child)
                 nodes.append(node)
-
-        # The ordering of nodes currently only works if namespaces are
-        # defined in XML.
-        # Also, it is recommended not to use node ids without namespace prefix!
-        if self.namespaces:
-            nodes = self._sort_nodes_by_parentid(nodes)
 
         self.it = iter(nodes)
         return self
@@ -133,101 +126,6 @@ class XMLParser(object):
 
     def next(self):  # support for python2
         return self.__next__()
-
-    def _sort_nodes_by_parentid(self, nodes):
-        """
-        Sort the list of nodes according theire parent node in order to respect
-        the depency between nodes.
-
-        :param nodes: list of NodeDataObjects
-        :returns: list of sorted nodes
-        """
-        _nodes = list(nodes)
-        # list of node ids that are already sorted / inserted
-        sorted_nodes_ids = []
-        # list of sorted nodes (i.e. XML Elements)
-        sorted_nodes = []
-        # list of namespace indexes that are relevant for this import
-        # we can only respect ordering nodes for namespaces indexes that
-        # are defined in the xml file itself. Thus we assume that all other
-        # references namespaces are already known to the server and should
-        # not create any dependency problems (like "NodeNotFound")
-        relevant_namespaces = [str(i[0]) for i in self.namespaces.values()]
-        while len(_nodes) > 0:
-            pop_nodes = []
-            for node in _nodes:
-                insert = None
-                # Get the node and parent node namespace and id parts
-                node_ns, node_id = self._split_node_id(node.nodeid)
-                parent_ns, parent_id = self._split_node_id(node.parent)
-
-                # Insert nodes that
-                #   (1) have no parent / parent_ns is None (e.g. namespace 0)
-                #   (2) ns is not in list of relevant namespaces
-                if (parent_ns is None or node_ns not in relevant_namespaces or
-                    parent_id is None):
-                    insert = 0
-                else:
-                    # Check if the nodes parent is already in the list of
-                    # inserted nodes
-                    if node.parent in sorted_nodes_ids:
-                        insert = -1
-
-                if insert == 0:
-                    sorted_nodes.insert(insert, node)
-                    sorted_nodes_ids.insert(insert, node.nodeid)
-                    pop_nodes.append(node)
-                elif insert == -1:
-                    sorted_nodes.append(node)
-                    sorted_nodes_ids.append(node.nodeid)
-                    pop_nodes.append(node)
-
-            # Remove inserted nodes from the list
-            for node in pop_nodes:
-                _nodes.pop(_nodes.index(node))
-        return sorted_nodes
-
-    def _split_node_id(self, value):
-        """
-        Split the fq node id into namespace and id part.
-
-        :returns: (namespace, id)
-        """
-        if not value:
-            return (None, value)
-        r_match = self._re_nodeid.search(value)
-        if r_match:
-            return r_match.groups()
-
-        return (None, value)
-
-    def _get_node_id(self, value):
-        """
-        Check if the nodeid given in the xml model file must be converted
-        to a already existing namespace id based on the files namespace uri
-
-        :returns: NodeId (str)
-        """
-        result = value
-
-        node_ns, node_id = self._split_node_id(value)
-        if node_ns:
-            ns_server = self.namespaces.get(int(node_ns), None)
-            if ns_server:
-                result = "ns={};i={}".format(ns_server[0], node_id)
-        return result
-
-    def _parse_bname(self, bname):
-        """
-        Parse a browsename and correct the namespace index.
-        """
-        if bname.find(':') != -1:
-            browse_ns, browse_name = bname.split(':')
-            if browse_ns:
-                ns_server = self.namespaces.get(int(browse_ns), None)
-                if ns_server:
-                    return '%d:%s' % (ns_server[0], browse_name)
-        return bname
 
     def _parse_node(self, name, child):
         """
@@ -245,13 +143,13 @@ class XMLParser(object):
 
     def _set_attr(self, key, val, obj):
         if key == "NodeId":
-            obj.nodeid = self._get_node_id(val)
+            obj.nodeid = val
         elif key == "BrowseName":
-            obj.browsename = self._parse_bname(val)
+            obj.browsename = val
         elif key == "SymbolicName":
             obj.symname = val
         elif key == "ParentNodeId":
-            obj.parent = self._get_node_id(val)
+            obj.parent = val
         elif key == "DataType":
             obj.datatype = val
         elif key == "IsAbstract":
@@ -385,16 +283,16 @@ class XMLParser(object):
     def _parse_refs(self, el, obj):
         for ref in el:
             if ref.attrib["ReferenceType"] == "HasTypeDefinition":
-                obj.typedef = self._get_node_id(ref.text)
+                obj.typedef = ref.text
             elif "IsForward" in ref.attrib and ref.attrib["IsForward"] in ("false", "False"):
                 # if obj.parent:
                     # sys.stderr.write("Parent is already set with: "+ obj.parent + " " + ref.text + "\n")
-                obj.parent = self._get_node_id(ref.text)
+                obj.parent = ref.text
                 obj.parentlink = ref.attrib["ReferenceType"]
             else:
                 struct = RefStruct()
                 if "IsForward" in ref.attrib:
                     struct.forward = ref.attrib["IsForward"]
-                struct.target = self._get_node_id(ref.text)
+                struct.target = ref.text
                 struct.reftype = ref.attrib["ReferenceType"]
                 obj.refs.append(struct)

--- a/tests/custom_nodes.xml
+++ b/tests/custom_nodes.xml
@@ -11,7 +11,7 @@
      <Alias Alias="MyEnumVal">ns=1;i=3011</Alias>
   </Aliases>
 
-  <UAObject NodeId="i=30001" BrowseName="MyXMLFolder"  >
+  <UAObject NodeId="ns=1;i=30001" BrowseName="1:MyXMLFolder"  >
     <Description>A custom folder.</Description>
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=61</Reference>
@@ -20,40 +20,40 @@
   </UAObject>
 
 
-  <UAObject NodeId="i=30002" BrowseName="MyXMLObject">
+  <UAObject NodeId="ns=1;i=30002" BrowseName="1:MyXMLObject">
     <Description>A custom object node.</Description>
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=58</Reference>
-      <Reference ReferenceType="Organizes" IsForward="false">i=30001</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=30001</Reference>
     </References>
   </UAObject>
 
 
-  <UAVariable NodeId="i=30004" BrowseName="MyXMLVariable" DataType="String">
+  <UAVariable NodeId="ns=1;i=30004" BrowseName="1:MyXMLVariable" DataType="String">
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
-      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=30002</Reference>
     </References>
     <Value>
       <String>StringValue</String>
     </Value>
   </UAVariable>
 
-  <UAVariable NodeId="i=30005" BrowseName="MyXMLProperty" DataType="UInt32">
+  <UAVariable NodeId="ns=1;i=30005" BrowseName="1:MyXMLProperty" DataType="UInt32">
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
-      <Reference ReferenceType="HasProperty" IsForward="false">i=30002</Reference>
+      <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=30002</Reference>
     </References>
     <Value>
       <UInt32>76</UInt32>
     </Value>
   </UAVariable>
 
-  <UAVariable NodeId="i=30006" BrowseName="MyXMLVariableWithoutValue" DataType="String">
+  <UAVariable NodeId="ns=1;i=30006" BrowseName="1:MyXMLVariableWithoutValue" DataType="String">
     <References>
     
       <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
-      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=30002</Reference>
     </References>
   </UAVariable>
   
@@ -64,10 +64,10 @@
     </References>
   </UADataType>
 	
-  <UAVariable NodeId="i=30007" BrowseName="MyCustomTypeVar" DataType="MyCustomString">
+  <UAVariable NodeId="ns=1;i=30007" BrowseName="1:MyCustomTypeVar" DataType="MyCustomString">
     <References>
       <Reference ReferenceType="HasTypeDefinition">i=69</Reference>
-      <Reference ReferenceType="Organizes" IsForward="false">i=30002</Reference>
+      <Reference ReferenceType="Organizes" IsForward="false">ns=1;i=30002</Reference>
     </References>
   </UAVariable>
   

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -51,6 +51,12 @@ class XmlTests(object):
         v1 = o.get_child(["%d:MyBaseObject" % ns, "%d:MyVar" % ns])
         self.assertIsNotNone(v1)
 
+        r1 = o2.get_references(refs=ua.ObjectIds.HasComponent)[0]
+        self.assertEqual(r1.NodeId.NamespaceIndex, ns)
+
+        r3 = v1.get_references(refs=ua.ObjectIds.HasComponent)[0]
+        self.assertEqual(r3.NodeId.NamespaceIndex, ns)
+
     def test_xml_method(self):
         o = self.opc.nodes.objects.add_object(2, "xmlexportobj")
         m = o.add_method(2, "callme", func, [ua.VariantType.Double, ua.VariantType.String], [ua.VariantType.Float])

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -13,7 +13,7 @@ class XmlTests(object):
     def test_xml_import(self):
         self.srv.import_xml("tests/custom_nodes.xml")
         o = self.opc.get_objects_node()
-        v = o.get_child(["MyXMLFolder", "MyXMLObject", "MyXMLVariable"])
+        v = o.get_child(["1:MyXMLFolder", "1:MyXMLObject", "1:MyXMLVariable"])
         val = v.get_value()
         self.assertEqual(val, "StringValue")
 


### PR DESCRIPTION
First attempt to move namespace correction code out of xmlparser to xmlimport.

Part not finished sorting the nodes before import (_sort_nodes_by_parentid). This is a problem if the nodes not already are sorted in the xml file (default behavioral of UaModeler is sorted).

Please review and/or test.