### PR TITLE
Fix Guid implemenetation

### DIFF
--- a/opcua/common/ua_utils.py
+++ b/opcua/common/ua_utils.py
@@ -79,7 +79,7 @@ def string_to_val(string, vtype):
         val = float(string)
     elif vtype in (ua.VariantType.String, ua.VariantType.XmlElement):
         val = string
-    elif vtype in (ua.VariantType.SByte, ua.VariantType.Guid, ua.VariantType.ByteString):
+    elif vtype in (ua.VariantType.SByte, ua.VariantType.ByteString):
         val = bytes(string)
     elif vtype in (ua.VariantType.NodeId, ua.VariantType.ExpandedNodeId):
         val = ua.NodeId.from_string(string)
@@ -91,6 +91,8 @@ def string_to_val(string, vtype):
         val = ua.LocalizedText(string)
     elif vtype == ua.VariantType.StatusCode:
         val = ua.StatusCode(string)
+    elif vtype == ua.VariantType.Guid:
+        val = ua.Guid(string)
     else:
         # FIXME: Some types are probably missing!
         raise NotImplementedError

--- a/opcua/common/xmlexporter.py
+++ b/opcua/common/xmlexporter.py
@@ -328,6 +328,9 @@ def _val_to_etree(el, dtype, val):
     if dtype == ua.NodeId(ua.ObjectIds.NodeId):
         id_el = Et.SubElement(el, "uax:Identifier")
         id_el.text = val.to_string()
+    elif dtype == ua.NodeId(ua.ObjectIds.Guid):
+        id_el = Et.SubElement(el, "uax:String")
+        id_el.text = str(val.uuid)
     elif not hasattr(val, "ua_types"):
         if type(val) is bytes:
             el.text = val.decode("utf-8")

--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -253,7 +253,7 @@ class XmlImporter(object):
 
     def _add_variable_value(self, obj):
         """
-        Returns the value for a Variable based on the objects valuetype. 
+        Returns the value for a Variable based on the objects value type.
         """
         if obj.valuetype == 'ListOfExtensionObject':
             values = []
@@ -267,6 +267,8 @@ class XmlImporter(object):
         elif obj.valuetype == 'ExtensionObject':
             extobj = self._make_ext_obj(obj.value)
             return ua.Variant(extobj, getattr(ua.VariantType, obj.valuetype))
+        elif obj.valuetype == 'Guid':
+            return ua.Variant(ua.Guid(obj.value), getattr(ua.VariantType, obj.valuetype))
         else:
             return ua.Variant(obj.value, getattr(ua.VariantType, obj.valuetype))
 
@@ -357,7 +359,7 @@ class XmlImporter(object):
     def _sort_nodes_by_parentid(self, nodes):
         """
         Sort the list of nodes according theire parent node in order to respect
-        the depency between nodes.
+        the dependency between nodes.
 
         :param nodes: list of NodeDataObjects
         :returns: list of sorted nodes

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -4,7 +4,7 @@ parse xml file from opcua-spec
 import logging
 import re
 import sys
-
+import dateutil.parser
 import xml.etree.ElementTree as ET
 
 
@@ -211,6 +211,8 @@ class XMLParser(object):
                 mytext = mytext.replace('\n', '').replace('\r', '')
                 # obj.value.append('b"{}"'.format(mytext))
                 obj.value = mytext
+            elif ntag in ("DateTime"):
+                obj.value = dateutil.parser.parse(val.text)
             elif ntag in ("Guid"):
                 self._parse_value(val, obj)
                 obj.valuetype = obj.datatype  # FIXME hack to keep a String variant from being created

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -213,6 +213,7 @@ class XMLParser(object):
                 obj.value = mytext
             elif ntag in ("Guid"):
                 self._parse_value(val, obj)
+                obj.valuetype = obj.datatype  # FIXME hack to keep a String variant from being created
             elif ntag == "ListOfExtensionObject":
                 obj.value = self._parse_list_of_extension_object(el)
             elif ntag == "ListOfLocalizedText":


### PR DESCRIPTION
Improve handling, importing, and exporting of Guids, minor pep fixes

I left the "ua types" style implementation because it was already present. In my opinion treating Guid as a primitive would probably be better, but this will work for now.

One important note that this implementation doesn't protect against doing this:
```myvar = myobj.add_variable(idx, "MyGuid", ua.Variant(uuid.uuid4(), ua.VariantType.Guid))```
This will create a Variant of type Guid which has a Value containing a UUID object instead of a Guid object. This will result in binary errors and I couldn't come up with a nice way of protecting the user from it. The only protection from it is if they do this:
```myvar = myobj.add_variable(idx, "MyGuid", ua.Variant(uuid.uuid4()))```
In this case the `guess_type` code will raise an error and tell the user to supply a ua.Guid().

A second important note is that `node.get_value()` will return a Guid object, not the actual UUID as a string. Perhaps Guid class needs to override the get builtin...

See https://github.com/FreeOpcUa/python-opcua/issues/334 for more discussion.