### PR TITLE
Default value on import

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -50,12 +50,12 @@ class XmlImporter(object):
             aliases_mapped[alias] = self._migrate_ns(self.to_nodeid(node_id))
         return aliases_mapped
 
-    def import_xml(self, xmlpath):
+    def import_xml(self, xmlpath, enable_default_values=False):
         """
         import xml and return added nodes
         """
         self.logger.info("Importing XML file %s", xmlpath)
-        self.parser = xmlparser.XMLParser(xmlpath)
+        self.parser = xmlparser.XMLParser(xmlpath, enable_default_values)
 
         dnodes = self.parser.get_node_datas()
         dnodes = self.make_objects(dnodes)

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -90,11 +90,22 @@ class ExtObj(object):
 
 
 class XMLParser(object):
+    """
+    XML Parser class which traverses an XML document to collect all information required for creating an address space
+    """
 
-    def __init__(self, xmlpath):
+    def __init__(self, xmlpath, enable_default_values=False):
+        """
+        Constructor for XML parser
+        Args:
+            xmlpath: path to the xml document; the document must be in OPC UA defined format
+            enable_default_values: false results in xml variable nodes with no Value element being converted to Null
+                                   true results in XML variable nodes to keep defined datatype with a default value
+        """
         self.logger = logging.getLogger(__name__)
         self._retag = re.compile(r"(\{.*\})(.*)")
         self.path = xmlpath
+        self.enable_default_values = enable_default_values
 
         self.tree = ET.parse(xmlpath)
         self.root = self.tree.getroot()
@@ -156,6 +167,23 @@ class XMLParser(object):
             self._set_attr(key, val, obj)
         self.logger.info("\n     Parsing node: %s %s", obj.nodeid, obj.browsename)
         obj.displayname = obj.browsename  # give a default value to display name
+
+        # set default Value based on type; avoids nodes with Value=None being converted to type Null by server
+        if self.enable_default_values:
+            if obj.datatype is not None:
+                if obj.datatype in ("Int8", "UInt8", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64"):
+                    obj.valuetype = obj.datatype
+                    obj.value = 0
+                elif obj.datatype in ("Float", "Double"):
+                    obj.valuetype = obj.datatype
+                    obj.value = 0.0
+                elif obj.datatype in ("Boolean"):
+                    obj.valuetype = obj.datatype
+                    obj.value = False
+                elif obj.datatype in ("ByteString", "String"):
+                    obj.valuetype = obj.datatype
+                    obj.value = ""
+
         for el in child:
             self._parse_tag(el, obj)
         return obj

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -396,12 +396,12 @@ class Server(object):
 
         return custom_t
 
-    def import_xml(self, path):
+    def import_xml(self, path, enable_default_values=False):
         """
         Import nodes defined in xml
         """
         importer = xmlimporter.XmlImporter(self)
-        return importer.import_xml(path)
+        return importer.import_xml(path, enable_default_values)
 
     def export_xml(self, nodes, path):
         """


### PR DESCRIPTION
Add option to importer which tries to preserve variable nodes data types
when they don't have a value

This stops variables from being converted to type Null by server (after which no client can write to them until the server changes the type).

Anyone who has an address space generated from Unified Automation Modeler will want this option.