### PR TITLE
Improve instantiate when parent has string node id + small fixes

### DIFF
--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -72,8 +72,10 @@ def _instantiate_node(server, parentid, rdesc, nodeid, bname, recursive=True):
             for c_rdesc in descs:
                 # skip items that already exists, prefer the 'lowest' one in object hierarchy
                 if not ua_utils.is_child_present(node, c_rdesc.BrowseName):
+                    # if root node being instantiated has a String NodeId, create the children with a String NodeId
                     if res.AddedNodeId.NodeIdType is ua.NodeIdType.String:
-                        nodeids = _instantiate_node(server, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(identifier=res.AddedNodeId.Identifier + "." + c_rdesc.BrowseName.Name, namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
+                        inst_nodeid = res.AddedNodeId.Identifier + "." + c_rdesc.BrowseName.Name
+                        nodeids = _instantiate_node(server, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(identifier=inst_nodeid, namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
                     else:
                         nodeids = _instantiate_node(server, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
                     added_nodes.extend(nodeids)

--- a/opcua/common/ua_utils.py
+++ b/opcua/common/ua_utils.py
@@ -74,8 +74,13 @@ def string_to_val(string, vtype):
     if vtype == ua.VariantType.Null:
         val = None
     elif vtype == ua.VariantType.Boolean:
-        val = bool(string)
-    elif 4 <= vtype.value < 9:
+        if string in ("True", "true", "on", "On", "1"):
+            val = True
+        else:
+            val = False
+    elif vtype in (ua.VariantType.Int16, ua.VariantType.Int32, ua.VariantType.Int64):
+            val = int(string)
+    elif vtype in (ua.VariantType.UInt16, ua.VariantType.UInt32, ua.VariantType.UInt64):
         val = int(string)
     elif vtype in (ua.VariantType.Float, ua.VariantType.Double):
         val = float(string)

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -208,7 +208,10 @@ class XMLParser(object):
 
     def _parse_value(self, val_el, obj):
         child_el = val_el.find(".//")  # should be only one child
-        ntag = self._retag.match(child_el.tag).groups()[1]
+        if child_el is not None:
+            ntag = self._retag.match(child_el.tag).groups()[1]
+        else:
+            ntag = "Null"
         obj.valuetype = ntag
 
         if ntag in ("Int8", "UInt8", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64"):
@@ -242,6 +245,8 @@ class XMLParser(object):
             obj.value = self._parse_list(child_el)
         elif ntag == "ExtensionObject":
             obj.value = self._parse_ext_obj(child_el)
+        elif ntag == "Null":
+            obj.value = None
         else:
             self.logger.warning("Parsing value of type '%s' not implemented", ntag)
 

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -136,7 +136,7 @@ class XMLParser(object):
         nodes = []
         for child in self.root:
             tag = self._retag.match(child.tag).groups()[1]
-            if tag not in ["Aliases", "NamespaceUris"]:
+            if tag not in ["Aliases", "NamespaceUris", "Extensions"]:  # these XML tags don't contain nodes
                 node = self._parse_node(tag, child)
                 nodes.append(node)
         return nodes

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -607,8 +607,29 @@ class CommonTests(object):
         prop1 = mydevicederived.get_child(["0:sensorx_id"])
         var1 = mydevicederived.get_child(["0:childparam"])
         var_parent = mydevicederived.get_child(["0:sensor"])
-        prop_parent = mydevicederived.get_child(["0:sensor_id"])        
+        prop_parent = mydevicederived.get_child(["0:sensor_id"])
 
+    def test_instantiate_string_nodeid(self):
+        # Create device type
+        dev_t = self.opc.nodes.base_object_type.add_object_type(0, "MyDevice2")
+        v_t = dev_t.add_variable(0, "sensor", 1.0)
+        p_t = dev_t.add_property(0, "sensor_id", "0340")
+        ctrl_t = dev_t.add_object(0, "controller")
+        prop_t = ctrl_t.add_property(0, "state", "Running")
+
+        # instanciate device
+        nodes = instantiate(self.opc.nodes.objects, dev_t, nodeid=ua.NodeId("InstDevice", 2, ua.NodeIdType.String), bname="2:InstDevice")
+        mydevice = nodes[0]
+
+        self.assertEqual(mydevice.get_node_class(), ua.NodeClass.Object)
+        self.assertEqual(mydevice.get_type_definition(), dev_t.nodeid)
+        obj = mydevice.get_child(["0:controller"])
+        obj_nodeid_ident = obj.nodeid.Identifier
+        prop = mydevice.get_child(["0:controller", "0:state"])
+        self.assertEqual(obj_nodeid_ident, "InstDevice.controller")
+        self.assertEqual(prop.get_type_definition().Identifier, ua.ObjectIds.PropertyType)
+        self.assertEqual(prop.get_value(), "Running")
+        self.assertNotEqual(prop.nodeid, prop_t.nodeid)
 
     def test_variable_with_datatype(self):
         v1 = self.opc.nodes.objects.add_variable(3, 'VariableEnumType1', ua.ApplicationType.ClientAndServer, datatype=ua.NodeId(ua.ObjectIds.ApplicationType))


### PR DESCRIPTION
Is there a way we can do something like this code?

Basically, if you have an ObjectType, and you instantiate from that type, but you want String Node Id (much more readable), the children will also have a string node id.

It looks like this:
![image](https://cloud.githubusercontent.com/assets/13090472/19699091/7d3d9e26-9ab7-11e6-9a9b-7ece9b05502a.png)

And when you instantiate the new node with a String Node Id:
![image](https://cloud.githubusercontent.com/assets/13090472/19699127/a2acfbc0-9ab7-11e6-8095-841a3ec8cf24.png)

I feel like this will work fine because the parent node will always be unique, but perhaps if you have some strange structures this would break? Having children with the same browsename would also break this, but I think `instantiate` is already broken in this case because `if not ua_utils.is_child_present(node, c_rdesc.BrowseName)` is already searching via browsename.

(the primary reason I want this is for Modeler)
