### PR TITLE
Exporter fix to allow exporting values of 0

### DIFF
--- a/opcua/common/xmlexporter.py
+++ b/opcua/common/xmlexporter.py
@@ -368,7 +368,7 @@ def value_to_etree(el, dtype_name, dtype, node):
 
 
 def _value_to_etree(el, type_name, dtype, val):
-    if not val:
+    if val is None:
         return
     if isinstance(val, (list, tuple)):
         if dtype.Identifier > 21:  # this is an extentionObject:


### PR DESCRIPTION
Can't check `not val` because variable nodes with a value of 0.0 don't get exported, for example. Only Null Variants should be exported with an empty `<Value>` tag.