### PR TITLE
Caching fixes

### DIFF
--- a/examples/server-datavalue-history.py
+++ b/examples/server-datavalue-history.py
@@ -26,14 +26,14 @@ if __name__ == "__main__":
     myvar = myobj.add_variable(idx, "MyVariable", ua.Variant(0, ua.VariantType.Double))
     myvar.set_writable()  # Set MyVariable to be writable by clients
 
-    # Configure server to use sqlite as history database (default is a simple in memory dict)
+    # Configure server to use sqlite as history database (default is a simple memory dict)
     server.iserver.history_manager.set_storage(HistorySQLite("my_datavalue_history.sql"))
 
     # starting!
     server.start()
 
     # enable data change history for this particular node, must be called after start since it uses subscription
-    server.iserver.enable_history_data_change(myvar, period=None, count=100)
+    server.historize_node_data_change(myvar, period=None, count=100)
 
     try:
         count = 0

--- a/examples/server-events-history.py
+++ b/examples/server-events-history.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     # enable history for server events; must be called after start since it uses subscription
     server_node = server.get_node(ua.ObjectIds.Server)
-    server.iserver.enable_history_event(server_node, period=None)
+    server.historize_node_event(server_node, period=None)
 
     try:
         count = 0

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -493,50 +493,24 @@ class AddressSpace(object):
     def dump(self, path):
         """
         dump address space as binary to file; note that server must be stopped for this method to work
-        if caching is enabled when dumping the cache files and binary file are required to restore address space state!
         """
-        dump_cache = False
-        if hasattr(self._nodes, "cache"):
-            dump_cache = True
-
         # prepare nodes in address space for being serialized
-        for nodeid in list(self._nodes.keys()):
+        for nodeid in self._nodes.keys():
             node = self._nodes[nodeid]
 
             # if the node has a reference to a method call, remove it so the object can be serialized
             if hasattr(node, "call"):
                 self._nodes[nodeid].call = None
 
-            # if the address space is using a cache, update the shelve if the node exists in the shelve
-            if dump_cache:
-                if self._nodes.shelve_item(nodeid, self._nodes[nodeid]):
-                    del self._nodes.cache[nodeid]
-
-        # save the shelve changes to disk
-        if dump_cache:
-            self._nodes.source.sync()
-
         with open(path, 'wb') as f:
-            # if address space is using a cache, only dump whatever is remaining in cache (user nodes)
-            # the rest is saved in the shelve files
-            if dump_cache:
-                pickle.dump(self._nodes.cache, f, pickle.HIGHEST_PROTOCOL)
-            else:
-                pickle.dump(self._nodes, f, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(self._nodes, f, pickle.HIGHEST_PROTOCOL)
 
     def load(self, path):
         """
         load address space from file, overwriting everything in current address space
-        if the binary was created by a server using caching you must use caching! (the binary won't have
-        standard address space because it's in the cache files)
         """
         with open(path, 'rb') as f:
-            # if using a cache, restore the data to cache
-            if hasattr(self._nodes, "cache"):
-                self._nodes.cache = pickle.load(f)
-            # otherwise overwrite the entire address space
-            else:
-                self._nodes = pickle.load(f)
+            self._nodes = pickle.load(f)
 
     def make_cache(self, path):
         """
@@ -547,8 +521,6 @@ class AddressSpace(object):
         for nodeid in self._nodes.keys():
             s[nodeid.to_string()] = self._nodes[nodeid]
         s.close()
-
-        self.load_cache(path)
 
     def load_cache(self, path):
         """
@@ -580,7 +552,7 @@ class AddressSpace(object):
 
             def __delitem__(self, key):
                 # only deleting items from the cache is allowed
-                del(self.cache[key])
+                del self.cache[key]
 
             def __iter__(self):
                 # only the cache can be iterated over
@@ -590,17 +562,7 @@ class AddressSpace(object):
                 # only returns the length of items in the cache, not unaccessed items in the shelve
                 return len(self.cache)
 
-            def shelve_item(self, key, value):
-                # update the shelf with a new value
-                # must call sync on the shelve after using this method to save to disk!
-                key = key.to_string()
-                if key in self.source:
-                    self.source[key] = value
-                    return True
-                else:
-                    return False
-
-        self._nodes = LazyLoadingDict(shelve.open(path, "r+"))
+        self._nodes = LazyLoadingDict(shelve.open(path, "r"))
 
     def get_attribute_value(self, nodeid, attr):
         with self._lock:

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 import collections
 import shelve
-from itertools import chain
 try:
     import cPickle as pickle
 except:

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -94,7 +94,7 @@ class InternalServer(object):
 
         if shelffile and (path.isfile(shelffile) or path.isfile(shelffile_win)):
             # import address space from shelf
-            self.aspace.load_lazy_dict(shelffile)
+            self.aspace.load_aspace_shelf(shelffile)
         else:
             # import address space from code generated from xml
             standard_address_space.fill_address_space(self.node_mgt_service)

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -92,7 +92,7 @@ class InternalServer(object):
         if cachefile_win:
             cachefile_win += ".dat"
 
-        if cachefile is not None and path.isfile(cachefile) or path.isfile(cachefile_win):
+        if cachefile and (path.isfile(cachefile) or path.isfile(cachefile_win)):
             # import address space from shelve
             self.aspace.load_cache(cachefile)
         else:

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -47,7 +47,7 @@ class ServerDesc(object):
 
 class InternalServer(object):
 
-    def __init__(self, cachefile=None):
+    def __init__(self, shelffile=None):
         self.logger = logging.getLogger(__name__)
 
         self.server_callback_dispatcher = CallbackDispatcher()
@@ -64,7 +64,7 @@ class InternalServer(object):
         self.method_service = MethodService(self.aspace)
         self.node_mgt_service = NodeManagementService(self.aspace)
 
-        self.load_standard_address_space(cachefile)
+        self.load_standard_address_space(shelffile)
 
         self.loop = utils.ThreadLoop()
         self.asyncio_transports = []
@@ -86,15 +86,15 @@ class InternalServer(object):
         ns_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
         ns_node.set_value(uries)
 
-    def load_standard_address_space(self, cachefile=None):
-        # check for a cache file, in windows the file extension is also needed for the check
-        cachefile_win = cachefile
-        if cachefile_win:
-            cachefile_win += ".dat"
+    def load_standard_address_space(self, shelffile=None):
+        # check for a python shelf file, in windows the file extension is also needed for the check
+        shelffile_win = shelffile
+        if shelffile_win:
+            shelffile_win += ".dat"
 
-        if cachefile and (path.isfile(cachefile) or path.isfile(cachefile_win)):
-            # import address space from shelve
-            self.aspace.load_cache(cachefile)
+        if shelffile and (path.isfile(shelffile) or path.isfile(shelffile_win)):
+            # import address space from shelf
+            self.aspace.load_lazy_dict(shelffile)
         else:
             # import address space from code generated from xml
             standard_address_space.fill_address_space(self.node_mgt_service)
@@ -103,8 +103,8 @@ class InternalServer(object):
             # importer.import_xml("/path/to/python-opcua/schemas/Opc.Ua.NodeSet2.xml", self)
 
             # if a cache file was supplied a shelve of the standard address space can now be built for next start up
-            if cachefile:
-                self.aspace.make_cache(cachefile)
+            if shelffile:
+                self.aspace.make_aspace_shelf(shelffile)
 
     def load_address_space(self, path):
         """

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -74,7 +74,7 @@ class Server(object):
 
     """
 
-    def __init__(self, cachefile=None, iserver=None):
+    def __init__(self, shelffile=None, iserver=None):
         self.logger = logging.getLogger(__name__)
         self.endpoint = urlparse("opc.tcp://0.0.0.0:4840/freeopcua/server/")
         self.application_uri = "urn:freeopcua:python:server"
@@ -85,7 +85,7 @@ class Server(object):
         if iserver is not None:
             self.iserver = iserver
         else:
-            self.iserver = InternalServer(cachefile)
+            self.iserver = InternalServer(shelffile)
         self.bserver = None
         self._discovery_clients = {}
         self._discovery_period = 60

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -3,6 +3,7 @@ High level interface to pure python OPC-UA server
 """
 
 import logging
+from datetime import timedelta
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -414,17 +415,19 @@ class Server(object):
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.iserver.isession, nodes, recursive)
 
-    def historize_node_data_change(self, node):
+    def historize_node_data_change(self, node, period=timedelta(days=7), count=0):
         """
         Start historizing supplied nodes; see history module
         Args:
             node: node or list of nodes that can be historized (variables/properties)
+            period: time delta to store the history; older data will be deleted from the storage
+            count: number of changes to store in the history
 
         Returns:
         """
         nodes = [node]
         for node in nodes:
-            self.iserver.enable_history_data_change(node)
+            self.iserver.enable_history_data_change(node, period, count)
 
     def dehistorize_node_data_change(self, node):
         """
@@ -438,17 +441,19 @@ class Server(object):
         for node in nodes:
             self.iserver.disable_history_data_change(node)
 
-    def historize_node_event(self, node):
+    def historize_node_event(self, node, period=timedelta(days=7), count=0):
         """
         Start historizing events from node (typically a UA object); see history module
         Args:
             node: node or list of nodes that can be historized (UA objects)
+            period: time delta to store the history; older data will be deleted from the storage
+            count: number of events to store in the history
 
         Returns:
         """
         nodes = [node]
         for node in nodes:
-            self.iserver.enable_history_event(node)
+            self.iserver.enable_history_event(node, period, count)
 
     def dehistorize_node_event(self, node):
         """

--- a/tests/tests_history.py
+++ b/tests/tests_history.py
@@ -17,7 +17,6 @@ port_num1 = 48530
 port_num2 = 48530
 
 
-
 class HistoryCommon(object):
     srv = Server
     clt = Client
@@ -41,7 +40,7 @@ class HistoryCommon(object):
         o = cls.srv.get_objects_node()
         cls.values = [i for i in range(20)]
         cls.var = o.add_variable(3, "history_var", 0)
-        cls.srv.iserver.enable_history_data_change(cls.var, period=None, count=0)
+        cls.srv.historize_node_data_change(cls.var, period=None, count=0)
         for i in cls.values:
             cls.var.set_value(i)
         time.sleep(1)
@@ -156,14 +155,13 @@ class TestHistoryEvents(object):
         cls.srvevgen = cls.srv.get_event_generator()
 
         cls.srv_node = cls.srv.get_node(ua.ObjectIds.Server)
-        cls.srv.iserver.enable_history_event(cls.srv_node, period=None)
+        cls.srv.historize_node_event(cls.srv_node, period=None)
 
         for i in cls.ev_values:
             cls.srvevgen.event.Severity = cls.ev_values[i]
             cls.srvevgen.trigger(message="test message")
             time.sleep(.1)
         time.sleep(2)
-
 
     # only has end time, should return reverse order
     def test_history_ev_read_2_with_end(self):
@@ -266,7 +264,7 @@ class TestHistoryLimitsCommon(unittest.TestCase):
         self.history.save_node_value(self.id, value)
 
     def test_count_limit(self):
-        self.history.new_historized_node(self.id, period = None, count = 3)
+        self.history.new_historized_node(self.id, period=None, count=3)
         self.assertEqual(self.resultCount(), 0)
         self.addValue(5)
         self.assertEqual(self.resultCount(), 1)
@@ -280,7 +278,7 @@ class TestHistoryLimitsCommon(unittest.TestCase):
         self.assertEqual(self.resultCount(), 3)
 
     def test_period_limit(self):
-        self.history.new_historized_node(self.id, period = timedelta(hours = 3))
+        self.history.new_historized_node(self.id, period=timedelta(hours=3))
         self.assertEqual(self.resultCount(), 0)
         self.addValue(5)
         self.assertEqual(self.resultCount(), 0)
@@ -294,7 +292,7 @@ class TestHistoryLimitsCommon(unittest.TestCase):
         self.assertEqual(self.resultCount(), 3)
 
     def test_combined_limit(self):
-        self.history.new_historized_node(self.id, period = timedelta(hours = 3), count = 2)
+        self.history.new_historized_node(self.id, period=timedelta(hours=3), count=2)
         self.assertEqual(self.resultCount(), 0)
         self.addValue(5)
         self.assertEqual(self.resultCount(), 0)
@@ -311,6 +309,7 @@ class TestHistoryLimitsCommon(unittest.TestCase):
 class TestHistoryLimits(TestHistoryLimitsCommon):
     def createHistoryInstance(self):
         return HistoryDict()
+
 
 class TestHistorySQLLimits(TestHistoryLimitsCommon):
     def createHistoryInstance(self):

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -456,7 +456,7 @@ class TestServerCaching(unittest.TestCase):
         tmpfile.close()
 
         # create cache file
-        server = Server(cachefile=path)
+        server = Server(shelffile=path)
 
         # modify cache content
         id = ua.NodeId(ua.ObjectIds.Server_ServerStatus_SecondsTillShutdown)
@@ -465,7 +465,7 @@ class TestServerCaching(unittest.TestCase):
         s.close()
 
         # ensure that we are actually loading from the cache
-        server = Server(cachefile=path)
+        server = Server(shelffile=path)
         self.assertEqual(server.get_node(id).get_value(), 123)
 
         os.remove(path)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -456,8 +456,7 @@ class TestServerCaching(unittest.TestCase):
         tmpfile.close()
 
         # create cache file
-        server = Server()
-        server.iserver.dump_address_space(path)
+        server = Server(cachefile=path)
 
         # modify cache content
         id = ua.NodeId(ua.ObjectIds.Server_ServerStatus_SecondsTillShutdown)
@@ -466,7 +465,7 @@ class TestServerCaching(unittest.TestCase):
         s.close()
 
         # ensure that we are actually loading from the cache
-        server = Server(cacheFile=path)
+        server = Server(cachefile=path)
         self.assertEqual(server.get_node(id).get_value(), 123)
 
         os.remove(path)


### PR DESCRIPTION
Bring back dump and load to do their original function and add methods for caching.

These serve different purposes.
load and dump: just dump the entire address space to binary and then reload it
cache: tries to speed up loading default address space, it doesn't support saving custom nodes and has other drawbacks; for example you can't delete nodes if using the cache

Also added `isession.close()` to the server stop code. This ensures all clean up is done, including the deletion of internal subscriptions (required for dumping address space)