### PR TITLE
Changed values for RequestedLifetimeCount and RequestedMaxKeepAliveCount

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -465,7 +465,7 @@ class Client(object):
         """
         return Node(self.uaclient, nodeid)
 
-    def create_subscription(self, period, handler):
+    def create_subscription(self, period, handler, lifetime_count=10000, max_keep_alive_count=3000):
         """
         Create a subscription.
         returns a Subscription object which allow
@@ -479,8 +479,8 @@ class Client(object):
         """
         params = ua.CreateSubscriptionParameters()
         params.RequestedPublishingInterval = period
-        params.RequestedLifetimeCount = 3000
-        params.RequestedMaxKeepAliveCount = 10000
+        params.RequestedLifetimeCount = lifetime_count
+        params.RequestedMaxKeepAliveCount = max_keep_alive_count
         params.MaxNotificationsPerPublish = 10000
         params.PublishingEnabled = True
         params.Priority = 0

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -476,6 +476,11 @@ class Client(object):
         Do not do expensive/slow or network operation from these methods
         since they are called directly from receiving thread. This is a design choice,
         start another thread if you need to do such a thing.
+        lifetime_count sets how many periods the server will wait for a publish request
+        from the client.
+        max_keep_alive_count sets how many periods the server will wait before sending
+        an empty publish response to the client, if no monitored item has changed. 
+        max_keep_alive_count should always be smaller then lifetime_count (approx 1/3).
         """
         params = ua.CreateSubscriptionParameters()
         params.RequestedPublishingInterval = period

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -465,27 +465,28 @@ class Client(object):
         """
         return Node(self.uaclient, nodeid)
 
-    def create_subscription(self, period, handler, lifetime_count=10000, max_keep_alive_count=3000):
+    def create_subscription(self, period, handler):
         """
         Create a subscription.
         returns a Subscription object which allow
         to subscribe to events or data on server
         handler argument is a class with data_change and/or event methods.
+        period argument is either a publishing interval in seconds or a 
+        CreateSubscriptionParameters instance. The second option should be used,
+        if the opcua-server has problems with the default options.
         These methods will be called when notfication from server are received.
         See example-client.py.
         Do not do expensive/slow or network operation from these methods
         since they are called directly from receiving thread. This is a design choice,
-        start another thread if you need to do such a thing.
-        lifetime_count sets how many periods the server will wait for a publish request
-        from the client.
-        max_keep_alive_count sets how many periods the server will wait before sending
-        an empty publish response to the client, if no monitored item has changed. 
-        max_keep_alive_count should always be smaller then lifetime_count (approx 1/3).
+        start another thread if you need to do such a thing.  
         """
+        
+        if isinstance(period, ua.CreateSubscriptionParameters):
+             return Subscription(self.uaclient, period, handler)
         params = ua.CreateSubscriptionParameters()
         params.RequestedPublishingInterval = period
-        params.RequestedLifetimeCount = lifetime_count
-        params.RequestedMaxKeepAliveCount = max_keep_alive_count
+        params.RequestedLifetimeCount = 10000
+        params.RequestedMaxKeepAliveCount = 3000
         params.MaxNotificationsPerPublish = 10000
         params.PublishingEnabled = True
         params.Priority = 0


### PR DESCRIPTION
I have switched the values for `RequestedLifetimeCount `and `RequestedMaxKeepAliveCount`, because on an idle connection (no changes of the monitored items) the server will wait for `KeepAliveCount*PublishingInterval` and then send an empty message to the client. This empty message will trigger a PublishRequests. Buf if `LifeTimeCount` is smaller than `KeepAliveCount`, the server will close the subscription before sending the empty message.

Also added the values as `kwargs` to create_subscription.

> KeepAliveCount
If there is no data to send after the next PublishingInterval, the server will skip it. But KeepAlive defines how many intervals may be skipped, before an empty notification is sent anyway: to give the client a hint that the subscription is still alive in the server and that there just has not been any data arriving to the client.
LifeTimeCount
The client’s responsibility is to send PublishRequests to the server, in order to enable the server to send PublishResponses back. The PublishResponses are used to deliver the notifications: but if there are no PublishRequests, the server cannot send a notification to the client.
The server will also verify that the client is alive by checking that new PublishRequests are received – LifeTimeCount defines the number of PublishingIntervals to wait for a new PublishRequest, before realizing that the client is no longer active. The Subscription is then removed from the server.
(see [source](https://www.prosysopc.com/blog/opc-ua-sessions-subscriptions-and-timeouts/))
