### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/opcua/common/callback.py
+++ b/opcua/common/callback.py
@@ -85,7 +85,7 @@ class CallbackDispatcher(object):
                 self.addListener(eventName, getattr(subscriber, params))
             elif isinstance(params, list):
                 if not params:
-                    raise ValueError('Invalid params "%r" for event "%s"' % (params, eventName))
+                    raise ValueError('Invalid params "{0!r}" for event "{1!s}"'.format(params, eventName))
                 if len(params) <= 2 and isinstance(params[0], str):
                     priority = params[1] if len(params) > 1 else 0
                     self.addListener(eventName, getattr(subscriber, params[0]), priority)
@@ -94,6 +94,6 @@ class CallbackDispatcher(object):
                         priority = listener[1] if len(listener) > 1 else 0
                         self.addListener(eventName, getattr(subscriber, listener[0]), priority)
             else:
-                raise ValueError('Invalid params for event "%s"' % eventName)
+                raise ValueError('Invalid params for event "{0!s}"'.format(eventName))
 
 

--- a/opcua/common/copy_node.py
+++ b/opcua/common/copy_node.py
@@ -73,5 +73,5 @@ def _read_and_copy_attrs(node_type, struct, addnode):
             else:
                 setattr(struct, name, results[idx].Value.Value)
         else:
-            print("Instantiate: while copying attributes from node type %s, attribute %s, statuscode is %s" % (node_type, name, results[idx].StatusCode))            
+            print("Instantiate: while copying attributes from node type {0!s}, attribute {1!s}, statuscode is {2!s}".format(node_type, name, results[idx].StatusCode))            
     addnode.NodeAttributes = struct

--- a/opcua/common/ua_utils.py
+++ b/opcua/common/ua_utils.py
@@ -230,7 +230,7 @@ def get_base_data_type(datatype):
         if base.nodeid.NamespaceIndex == 0 and isinstance(base.nodeid.Identifier, int) and base.nodeid.Identifier <= 30:
             return base
         base = get_node_supertype(base)
-    raise ua.UaError("Datatype must be a subtype of builtin types %s" % datatype)
+    raise ua.UaError("Datatype must be a subtype of builtin types {0!s}".format(datatype))
 
 
 def get_nodes_of_namespace(server, namespaces=None):

--- a/opcua/tools.py
+++ b/opcua/tools.py
@@ -704,7 +704,7 @@ def uacall():
             elif ( len( methods ) == 1 ):
                 method_id = methods[0]
             else:
-                raise ValueError( "Selected node has %d methods but no method given. Provide one of %s" % (methods) )
+                raise ValueError( "Selected node has {0:d} methods but no method given. Provide one of {1!s}".format(*(methods)) )
         else:
             for m in methods:
                 if ( m.nodeid.Identifier == args.method ):
@@ -718,7 +718,7 @@ def uacall():
         #print( "method_id=%s\nval=%s" % (method_id,val) )
 
         result_variants = node.call_method( method_id, *val )
-        print( "resulting result_variants=%s" % result_variants )
+        print( "resulting result_variants={0!s}".format(result_variants) )
     finally:
         client.disconnect()
     sys.exit(0)

--- a/opcua/ua/ua_binary.py
+++ b/opcua/ua/ua_binary.py
@@ -290,7 +290,7 @@ def unpack_uatype(vtype, data):
             klass = getattr(uatypes, vtype.name)
             return klass.from_binary(data)
         else:
-            raise UaError("can not unpack unknown vtype %s" % vtype)
+            raise UaError("can not unpack unknown vtype {0!s}".format(vtype))
 
 
 def unpack_uatype_array(vtype, data):

--- a/schemas/generate_address_space.py
+++ b/schemas/generate_address_space.py
@@ -75,8 +75,8 @@ It is automatically generated from opcfoundation.org schemas.
 from opcua import ua
 
 
-def create_standard_address_space_%s(server):
-  ''' % (self.part))
+def create_standard_address_space_{0!s}(server):
+  '''.format((self.part)))
 
     def make_node_code(self, obj, indent):
         self.writecode(indent, 'node = ua.AddNodesItem()')

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -22,18 +22,18 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests):
     def setUpClass(cls):
         # start our own server
         cls.srv = Server()
-        cls.srv.set_endpoint('opc.tcp://localhost:%d' % port_num1)
+        cls.srv.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num1))
         add_server_methods(cls.srv)
         cls.srv.start()
 
         # start admin client
         # long timeout since travis (automated testing) can be really slow
-        cls.clt = Client('opc.tcp://admin@localhost:%d' % port_num1, timeout=10)
+        cls.clt = Client('opc.tcp://admin@localhost:{0:d}'.format(port_num1), timeout=10)
         cls.clt.connect()
         cls.opc = cls.clt
 
         # start anonymous client
-        cls.ro_clt = Client('opc.tcp://localhost:%d' % port_num1)
+        cls.ro_clt = Client('opc.tcp://localhost:{0:d}'.format(port_num1))
         cls.ro_clt.connect()
 
     @classmethod

--- a/tests/tests_cmd_lines.py
+++ b/tests/tests_cmd_lines.py
@@ -15,7 +15,7 @@ class TestCmdLines(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.srv = Server()
-        cls.srv_url = 'opc.tcp://localhost:%d' % port_num
+        cls.srv_url = 'opc.tcp://localhost:{0:d}'.format(port_num)
         cls.srv.set_endpoint(cls.srv_url)
         objects = cls.srv.get_objects_node()
         obj = objects.add_object(4, "directory")

--- a/tests/tests_crypto_connect.py
+++ b/tests/tests_crypto_connect.py
@@ -28,7 +28,7 @@ class TestCryptoConnect(unittest.TestCase):
     def setUpClass(cls):
         # start our own server
         cls.srv_crypto = Server()
-        cls.uri_crypto = 'opc.tcp://localhost:%d' % port_num1
+        cls.uri_crypto = 'opc.tcp://localhost:{0:d}'.format(port_num1)
         cls.srv_crypto.set_endpoint(cls.uri_crypto)
         # load server certificate and private key. This enables endpoints
         # with signing and encryption.
@@ -38,7 +38,7 @@ class TestCryptoConnect(unittest.TestCase):
 
         # start a server without crypto
         cls.srv_no_crypto = Server()
-        cls.uri_no_crypto = 'opc.tcp://localhost:%d' % port_num2
+        cls.uri_no_crypto = 'opc.tcp://localhost:{0:d}'.format(port_num2)
         cls.srv_no_crypto.set_endpoint(cls.uri_no_crypto)
         cls.srv_no_crypto.start()
 

--- a/tests/tests_history.py
+++ b/tests/tests_history.py
@@ -24,10 +24,10 @@ class HistoryCommon(object):
     @classmethod
     def start_server_and_client(cls):
         cls.srv = Server()
-        cls.srv.set_endpoint('opc.tcp://localhost:%d' % port_num1)
+        cls.srv.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num1))
         cls.srv.start()
 
-        cls.clt = Client('opc.tcp://localhost:%d' % port_num1)
+        cls.clt = Client('opc.tcp://localhost:{0:d}'.format(port_num1))
         cls.clt.connect()
 
     @classmethod

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -31,13 +31,13 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
     @classmethod
     def setUpClass(cls):
         cls.srv = Server()
-        cls.srv.set_endpoint('opc.tcp://localhost:%d' % port_num)
+        cls.srv.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num))
         add_server_methods(cls.srv)
         cls.srv.start()
         cls.opc = cls.srv
         cls.discovery = Server()
         cls.discovery.set_application_uri("urn:freeopcua:python:discovery")
-        cls.discovery.set_endpoint('opc.tcp://localhost:%d' % port_discovery)
+        cls.discovery.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_discovery))
         cls.discovery.start()
 
     @classmethod

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -56,11 +56,11 @@ class XmlTests(object):
         ns = self.srv.get_namespace_index("http://examples.freeopcua.github.io/")
         o = self.opc.get_objects_node()
 
-        o2 = o.get_child(["%d:MyBaseObject" % ns])
+        o2 = o.get_child(["{0:d}:MyBaseObject".format(ns)])
 
         self.assertIsNotNone(o2)
 
-        v1 = o.get_child(["%d:MyBaseObject" % ns, "%d:MyVar" % ns])
+        v1 = o.get_child(["{0:d}:MyBaseObject".format(ns), "{0:d}:MyVar".format(ns)])
         self.assertIsNotNone(v1)
 
         r1 = o2.get_references(refs=ua.ObjectIds.HasComponent)[0]


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:FreeOpcUa:python-opcua?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:FreeOpcUa:python-opcua?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)