### PR TITLE
WIP: Suppress datachange events of internal source

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -388,8 +388,8 @@ class InternalSession(object):
             acks = []
         return self.subscription_service.publish(acks)
 
-    def set_silent_events(self, silent):
+    def disable_data_change_notification(self, disable):
         """
         Disable variables change events in case of an internal call
         """
-        self._silent_events = silent
+        self._silent_events = disable

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -263,6 +263,8 @@ class InternalSession(object):
         self.subscriptions = []
         self.logger.info("Created internal session %s", self.name)
         self._lock = Lock()
+        self._silent_events = False
+
 
     def __str__(self):
         return "InternalSession(name:{0}, user:{1}, id:{2}, auth_token:{3})".format(
@@ -321,7 +323,7 @@ class InternalSession(object):
             # If session is internal we need to store a copy og object, not a reference,
             # otherwise users may change it and we will not generate expected events
             params.NodesToWrite = [deepcopy(ntw) for ntw in params.NodesToWrite]
-        return self.iserver.attribute_service.write(params, self.user)
+        return self.iserver.attribute_service.write(params, self.user, self._silent_events and not self.external)
 
     def browse(self, params):
         return self.iserver.view_service.browse(params)
@@ -385,3 +387,9 @@ class InternalSession(object):
         if acks is None:
             acks = []
         return self.subscription_service.publish(acks)
+
+    def set_silent_events(self, silent):
+        """
+        Disable variables change events in case of an internal call
+        """
+        self._silent_events = silent

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -517,3 +517,9 @@ class Server(object):
         Returns:
         """
         self.iserver.isession.add_method_callback(node.nodeid, callback)
+
+    def disable_data_change_notification(self, disable):
+        """
+        Disable variables change events in case of an internal call
+        """
+        self.iserver.isession.disable_data_change_notification(disable)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -452,13 +452,13 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
 
         myhandler.reset()
 
-        # TODO: this feels not good. Maybe added set_silent_events to a higher class ?
-        self.opc.iserver.isession.set_silent_events(True)
+        self.opc.disable_data_change_notification(True)
         v1.set_value(6)
         self.assertRaises(TimeoutError, myhandler.future.result, timeout=0.010)
 
         sub.unsubscribe(handle1)
         sub.delete()
+        self.opc.disable_data_change_notification(False)
 
 
 def check_eventgenerator_SourceServer(test, evgen):


### PR DESCRIPTION
Make it possible to suppress datachange events of internal source by set set_silent_events(True).

Is related to issue #310, #365 and #145.