### PR TITLE
Removed duplicate code from XML parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install futures ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install trollius ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install enum34 ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install pytz ; fi
 # command to run tests
 script: ./run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,17 @@ language: python
 python:
   - "2.7"
   - "3.4"
-  - "pypy"  
+  - "pypy"
 # command to install dependencies
 install:
   - pip install python-dateutil
   - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then pip install cryptography ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then pip install pytz ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install futures ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install cryptography ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install trollius ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install enum34 ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install pytz ; fi
     #- if [[ $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then pip install cryptography ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install futures ; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install trollius ; fi

--- a/opcua/common/ua_utils.py
+++ b/opcua/common/ua_utils.py
@@ -79,14 +79,14 @@ def string_to_val(string, vtype):
         else:
             val = False
     elif vtype in (ua.VariantType.Int16, ua.VariantType.Int32, ua.VariantType.Int64):
-            val = int(string)
+        val = int(string)
     elif vtype in (ua.VariantType.UInt16, ua.VariantType.UInt32, ua.VariantType.UInt64):
         val = int(string)
     elif vtype in (ua.VariantType.Float, ua.VariantType.Double):
         val = float(string)
     elif vtype in (ua.VariantType.String, ua.VariantType.XmlElement):
         val = string
-    elif vtype in (ua.VariantType.SByte, ua.VariantType.ByteString):
+    elif vtype in (ua.VariantType.Byte, ua.VariantType.SByte, ua.VariantType.ByteString):
         val = string.encode("utf-8")
     elif vtype in (ua.VariantType.NodeId, ua.VariantType.ExpandedNodeId):
         val = ua.NodeId.from_string(string)

--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -233,6 +233,10 @@ class XmlImporter(object):
                 extobj = self._make_ext_obj(ext)
                 values.append(extobj)
             return values
+        elif obj.valuetype == 'ListOfGuid':
+            return ua.Variant([
+                uuid.UUID(guid) for guid in obj.value
+            ], getattr(ua.VariantType, obj.valuetype[6:]))
         elif obj.valuetype.startswith("ListOf"):
             vtype = obj.valuetype[6:]
             if hasattr(ua.ua_binary.Primitives, vtype):
@@ -242,8 +246,6 @@ class XmlImporter(object):
         elif obj.valuetype == 'ExtensionObject':
             extobj = self._make_ext_obj(obj.value)
             return ua.Variant(extobj, getattr(ua.VariantType, obj.valuetype))
-        elif obj.valuetype == 'DateTime':
-            return ua.Variant(dateutil.parser.parse(obj.value), getattr(ua.VariantType, obj.valuetype))
         elif obj.valuetype == 'Guid':
             return ua.Variant(uuid.UUID(obj.value), getattr(ua.VariantType, obj.valuetype))
         elif obj.valuetype == 'LocalizedText':

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -8,38 +8,21 @@ import sys
 
 import xml.etree.ElementTree as ET
 
+from opcua.common import ua_utils
+from opcua import ua
+
+
+def ua_type_to_python(val, uatype_as_str):
+    """
+    Converts a string value to a python value according to ua_utils.
+    """
+    return ua_utils.string_to_val(val, getattr(ua.VariantType, uatype_as_str))
 
 def _to_bool(val):
-    return val in ("True", "true", "on", "On", "1")
-
-
-def ua_type_to_python(val, uatype):
-    if uatype.startswith("Int") or uatype.startswith("UInt"):
-        return int(val)
-    elif uatype.lower().startswith("bool"):
-        return _to_bool(val)
-    elif uatype in ("Double", "Float"):
-        return float(val)
-    elif uatype == "String":
-        return val
-    elif uatype in ("SByte", "Byte", "Bytes", "ByteString", "ByteArray"):
-        if sys.version_info.major > 2:
-            return bytes(val, 'utf8')
-        else:
-            return val
-    elif uatype in ("DateTime"):
-        # Format specified in Part6 Mappings: 5.3.1.6 DateTime
-        try:
-            # Zulu datetime
-            return datetime.datetime.strptime(val, "%Y-%m-%dT%XZ")
-        except ValueError:
-            try:
-                # Timezone offset.
-                return datetime.datetime.strptime(val, "%Y-%m-%dT%X%Z")
-            except ValueError:
-                raise Exception("DateTime object does not meet specifications's format: ", val)
-    else:
-        raise Exception("Uatype not handled", uatype, " for val ", val)
+    """
+    Easy access to boolean conversion.
+    """
+    return ua_type_to_python(val, "Boolean")
 
 
 class NodeData(object):
@@ -209,7 +192,7 @@ class XMLParser(object):
         elif tag == "References":
             self._parse_refs(el, obj)
         elif tag == "Value":
-            self._parse_value(el, obj)
+            self._parse_contained_value(el, obj)
         elif tag == "InverseName":
             obj.inversename = el.text
         elif tag == "Definition":
@@ -218,64 +201,75 @@ class XMLParser(object):
         else:
             self.logger.info("Not implemented tag: %s", el)
 
+    def _parse_contained_value(self, el, obj):
+        """
+        Parse the child of el as a constant.
+        """
+        val_el = el.find(".//")  # should be only one child
+        self._parse_value(val_el, obj)
+
     def _parse_value(self, val_el, obj):
-        child_el = val_el.find(".//")  # should be only one child
-        if child_el is not None:
-            ntag = self._retag.match(child_el.tag).groups()[1]
+        """
+        Parse the node val_el as a constant.
+        """
+        if val_el is not None:
+            ntag = self._retag.match(val_el.tag).groups()[1]
         else:
             ntag = "Null"
-        obj.valuetype = ntag
 
-        if ntag in ("Int8", "UInt8", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64"):
-            obj.value = int(child_el.text)
-        elif ntag in ("Float", "Double"):
-            obj.value = float(child_el.text)
-        elif ntag == "Boolean":
-            obj.value = _to_bool(child_el.text)
+        obj.valuetype = ntag
+        if ntag == "Null":
+            obj.value = None
+        elif ntag in (
+                "SByte", "Byte",
+                "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64",
+                "Float", "Double",
+                "Boolean",
+                "DateTime" #FIXME Check format in a specific elif?
+        ):
+            # Elementary types have their parsing directly relying on ua_type_to_python.
+            obj.value = ua_type_to_python(val_el.text, ntag)
         elif ntag in ("ByteString", "String"):
-            mytext = child_el.text
-            if mytext is None:  # support importing null strings
+            mytext = ua_type_to_python(val_el.text, ntag)
+            if mytext is None:
+                # Support importing null strings.
                 mytext = ""
             mytext = mytext.replace('\n', '').replace('\r', '')
             obj.value = mytext
-        elif ntag == "DateTime":
-            obj.value = child_el.text
         elif ntag == "Guid":
-            self._parse_value(child_el, obj)
-            obj.valuetype = obj.datatype  # override parsed string type to guid
-        elif ntag == "LocalizedText":
-            obj.value = self._parse_body(child_el)
+            self._parse_contained_value(val_el, obj)
+            obj.valuetype = obj.datatype # Override parsed string type to guid.
         elif ntag == "NodeId":
-            id_el = child_el.find("uax:Identifier", self.ns)
+            id_el = val_el.find("uax:Identifier", self.ns)
             if id_el is not None:
                 obj.value = id_el.text
-        elif ntag == "ListOfExtensionObject":
-            obj.value = self._parse_list_of_extension_object(child_el)
+        elif ntag == "LocalizedText":
+            obj.value = self._parse_body(val_el)
         elif ntag == "ListOfLocalizedText":
-            obj.value = self._parse_list_of_localized_text(child_el)
+            obj.value = self._parse_list_of_localized_text(val_el)
+        elif ntag == "ListOfExtensionObject":
+            obj.value = self._parse_list_of_extension_object(val_el)
         elif ntag.startswith("ListOf"):
-            obj.value = self._parse_list(child_el)
+            # Default case for "ListOf" types.
+            # Should stay after particular cases (e.g.: "ListOfLocalizedText").
+            obj.value = []
+            for val_el in val_el:
+                tmp = NodeData()
+                self._parse_value(val_el, tmp)
+                # FIXME Do some checks on parsed element?
+                obj.value.append(tmp.value)
         elif ntag == "ExtensionObject":
-            obj.value = self._parse_ext_obj(child_el)
-        elif ntag == "Null":
-            obj.value = None
+            obj.value = self._parse_ext_obj(val_el)
         else:
+            # Missing according to string_to_val: XmlElement, ExpandedNodeId,
+            # QualifiedName, StatusCode.
+            # Missing according to ua.VariantType (also missing in string_to_val):
+            # DataValue, Variant, DiagnosticInfo.
             self.logger.warning("Parsing value of type '%s' not implemented", ntag)
 
     def _get_text(self, el):
         txtlist = [txt.strip() for txt in el.itertext()]
         return "".join(txtlist)
-
-    def _parse_list(self, el):
-        value = []
-        for val_el in el:
-            ntag = self._retag.match(val_el.tag).groups()[1]
-            if ntag.startswith("ListOf"):
-                val = self._parse_list(val_el)
-            else:
-                val = ua_type_to_python(val_el.text, ntag)
-            value.append(val)
-        return value
 
     def _parse_list_of_localized_text(self, el):
         value = []

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -2,6 +2,7 @@
 parse xml file from opcua-spec
 """
 import logging
+import datetime
 import re
 import sys
 
@@ -21,13 +22,24 @@ def ua_type_to_python(val, uatype):
         return float(val)
     elif uatype == "String":
         return val
-    elif uatype in ("Bytes", "Bytes", "ByteString", "ByteArray"):
+    elif uatype in ("SByte", "Byte", "Bytes", "ByteString", "ByteArray"):
         if sys.version_info.major > 2:
             return bytes(val, 'utf8')
         else:
             return val
+    elif uatype in ("DateTime"):
+        # Format specified in Part6 Mappings: 5.3.1.6 DateTime
+        try:
+            # Zulu datetime
+            return datetime.datetime.strptime(val, "%Y-%m-%dT%XZ")
+        except ValueError:
+            try:
+                # Timezone offset.
+                return datetime.datetime.strptime(val, "%Y-%m-%dT%X%Z")
+            except ValueError:
+                raise Exception("DateTime object does not meet specifications's format: ", val)
     else:
-        raise Exception("uatype nopt handled", uatype, " for val ", val)
+        raise Exception("Uatype not handled", uatype, " for val ", val)
 
 
 class NodeData(object):

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -197,7 +197,7 @@ class NodeManagementService(object):
             nodedata = NodeData(item.RequestedNewNodeId)
 
         if nodedata.nodeid in self._aspace:
-            self.logger.warning("AddNodesItem: node already exists")
+            self.logger.warning("AddNodesItem: Requested NodeId %s already exists", nodedata.nodeid)
             result.StatusCode = ua.StatusCode(ua.StatusCodes.BadNodeIdExists)
             return result
 
@@ -286,7 +286,7 @@ class NodeManagementService(object):
             return ua.StatusCode(ua.StatusCodes.BadUserAccessDenied)
 
         if item.NodeId not in self._aspace:
-            self.logger.warning("DeleteNodesItem: node does not exists")
+            self.logger.warning("DeleteNodesItem: NodeId %s does not exists", item.NodeId)
             return ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown)
 
         if item.DeleteTargetReferences:

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup, find_packages
 import sys
 
 if sys.version_info[0] < 3:
-    install_requires = ["python-dateutil", "enum34", "trollius", "futures"]
+    install_requires = ["python-dateutil", "enum34", "trollius", "futures", "pytz"]
 else:
-    install_requires = ["python-dateutil"]
+    install_requires = ["python-dateutil", "pytz"]
 
 setup(name="freeopcua",
       version="0.90.0",


### PR DESCRIPTION
Allows to parse ListOfDateTime values and seems to correct a typo for Bytes.

--

More details in issue #377 

By the way, XML with "Byte" and "SByte" gives me warning of non implemented types, however they are mentioned in documentation from OPC Fondation while "Bytes" is not. 
Is that a macro-type for both?