### PR TITLE
Improve deadband handling, skip if deadbandtype is none.

### DIFF
--- a/opcua/server/internal_subscription.py
+++ b/opcua/server/internal_subscription.py
@@ -205,8 +205,14 @@ class MonitoredItemService(object):
                     self.isub.enqueue_datachange_event(mid, event, mdata.queue_size)
 
     def deadband_callback(self, values, flt):
-        if (values.get_old_value() is None) or \
+        ua.DeadbandType.None_
+        if flt.DeadbandType == ua.DeadbandType.None_ or values.get_old_value() is None:
+            return True
+        elif flt.DeadbandType == ua.DeadbandType.Absolute and \
                 ((abs(values.get_current_value() - values.get_old_value())) > flt.DeadbandValue):
+            return True
+        elif flt.DeadbandType == ua.DeadbandType.Percent:
+            self.logger.warn("DeadbandType Percent is not implemented !")
             return True
         else:
             return False


### PR DESCRIPTION
Client can set a deadband filter to several types (Part 4 7.16.2). Currently this mode isn't checked.
This pr makes the check of those types explicit.

Also some errors can be prevent by this, for example when string type provides a filter with type None. The current situation results in some math checks with strings, which results in an exception.