### PR TITLE
xmlexport improve compat with xml schema

### DIFF
--- a/opcua/common/xmlexporter.py
+++ b/opcua/common/xmlexporter.py
@@ -407,20 +407,8 @@ class XmlExporter(object):
         id_el.text = dtype.to_string()
         body_el = Et.SubElement(obj_el, "uax:Body")
         struct_el = Et.SubElement(body_el, "uax:" + name)
-        items_keys = val.ua_types.keys()
-        skip_empty = False
-        if dtype == ua.NodeId(ua.ObjectIds.Argument):
-            skip_empty = True
-            items_keys = [name for name in ['Name',
-                                            'DataType',
-                                            'ValueRank',
-                                            'ArrayDimensions',
-                                            'Description'] if name in items_keys ]
-
-        for name in items_keys:
-            vtype = val.ua_types[name]
-            if skip_empty and getattr(val, name):
-                self.member_to_etree(struct_el, name, ua.NodeId(getattr(ua.ObjectIds, vtype)), getattr(val, name))
+        for name, vtype in val.ua_types.items():
+            self.member_to_etree(struct_el, name, ua.NodeId(getattr(ua.ObjectIds, vtype)), getattr(val, name))
 
 
     def indent(self, elem, level=0):


### PR DESCRIPTION
Improve compatibility with:
* https://opcfoundation.org/UA/2011/03/UANodeSet.xsd
* https://opcfoundation.org/UA/2008/02/Types.xsd
Impove this compatibility make it possible to read the information models into other tools like UaModeler.

Mostly fixes to garantee the order of the elements according the xsd:
* NamespaceUris: Make sure that the namespacuris are on top (above the aliases)
* UAVariable: Place the values below the references
* uax:Boolean:  values should be 'true' and 'false' (lower case)
* Argument: place the members in the correct order

Btw correct format of the xml file can be checked with XML validator against the XSD.