### PR TITLE
Importing bytesting objects from XML in Python3

### DIFF
--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -230,12 +230,12 @@ class XMLParser(object):
             if obj.value.tzinfo is None or obj.value.tzinfo.utcoffset(obj.value) is None:
                 utc.localize(obj.value) # FIXME Forcing to UTC if unaware, maybe should raise?
         elif ntag in ("ByteString", "String"):
-            mytext = ua_type_to_python(val_el.text, ntag)
+            mytext = val_el.text
             if mytext is None:
                 # Support importing null strings.
                 mytext = ""
             mytext = mytext.replace('\n', '').replace('\r', '')
-            obj.value = mytext
+            obj.value = ua_type_to_python(mytext, ntag)
         elif ntag == "Guid":
             self._parse_contained_value(val_el, obj)
             # Override parsed string type to guid.

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -243,6 +243,14 @@ class XmlTests(object):
     #    o = self.opc.nodes.objects.add_variable(2, "xmlltext_array", [ua.QualifiedName("erert", 5), ua.QualifiedName("erert33", 6)])
     #    self._test_xml_var_type(o, "qualified_name_array")
 
+    def test_xml_bytestring(self):
+        o = self.opc.nodes.objects.add_variable(2, "xmlltext", "mytext", ua.VariantType.ByteString)
+        self._test_xml_var_type(o, "bytestring")
+
+    def test_xml_bytestring_array(self):
+        o = self.opc.nodes.objects.add_variable(2, "xmlltext_array", ["mytext", "errsadf"], ua.VariantType.ByteString)
+        self._test_xml_var_type(o, "bytestring_array")
+
     def test_xml_localizedtext(self):
         o = self.opc.nodes.objects.add_variable(2, "xmlltext", ua.LocalizedText("mytext"))
         self._test_xml_var_type(o, "localized_text")

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -244,11 +244,11 @@ class XmlTests(object):
     #    self._test_xml_var_type(o, "qualified_name_array")
 
     def test_xml_bytestring(self):
-        o = self.opc.nodes.objects.add_variable(2, "xmlltext", "mytext", ua.VariantType.ByteString)
+        o = self.opc.nodes.objects.add_variable(2, "xmlltext", "mytext".encode("utf8"), ua.VariantType.ByteString)
         self._test_xml_var_type(o, "bytestring")
 
     def test_xml_bytestring_array(self):
-        o = self.opc.nodes.objects.add_variable(2, "xmlltext_array", ["mytext", "errsadf"], ua.VariantType.ByteString)
+        o = self.opc.nodes.objects.add_variable(2, "xmlltext_array", ["mytext".encode("utf8"), "errsadf".encode("utf8")], ua.VariantType.ByteString)
         self._test_xml_var_type(o, "bytestring_array")
 
     def test_xml_localizedtext(self):


### PR DESCRIPTION
Python3 is failing to import bytestring objects due to calling replace method after encoding the imported string into utf8.
This works with python2 but not python3 as reffered in issue #377 