### PR TITLE
Load Aliases before make_objects()

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -47,12 +47,11 @@ class XmlImporter(object):
         self.logger.info("Importing XML file %s", xmlpath)
         self.parser = xmlparser.XMLParser(xmlpath)
 
-        dnodes = self.parser.get_node_datas()
-        dnodes = self.make_objects(dnodes)
-
         self.namespaces = self._map_namespaces(self.parser.get_used_namespaces())
         self.aliases = self._map_aliases(self.parser.get_aliases())
-
+        
+        dnodes = self.parser.get_node_datas()
+        dnodes = self.make_objects(dnodes)
         nodes_parsed = self._sort_nodes_by_parentid(dnodes)
 
         nodes = []


### PR DESCRIPTION
This fixes the error when importing an xml file with aliases used in objects.

self.make_objects() uses self.to_nodeid() which can now take the defined aliases into account.