### PR TITLE
[xmil_import] Fixed (S)Byte string_to_val

### DIFF
--- a/opcua/common/ua_utils.py
+++ b/opcua/common/ua_utils.py
@@ -78,15 +78,15 @@ def string_to_val(string, vtype):
             val = True
         else:
             val = False
-    elif vtype in (ua.VariantType.Int16, ua.VariantType.Int32, ua.VariantType.Int64):
+    elif vtype in (ua.VariantType.SByte, ua.VariantType.Int16, ua.VariantType.Int32, ua.VariantType.Int64):
         val = int(string)
-    elif vtype in (ua.VariantType.UInt16, ua.VariantType.UInt32, ua.VariantType.UInt64):
+    elif vtype in (ua.VariantType.Byte, ua.VariantType.UInt16, ua.VariantType.UInt32, ua.VariantType.UInt64):
         val = int(string)
     elif vtype in (ua.VariantType.Float, ua.VariantType.Double):
         val = float(string)
     elif vtype in (ua.VariantType.String, ua.VariantType.XmlElement):
         val = string
-    elif vtype in (ua.VariantType.Byte, ua.VariantType.SByte, ua.VariantType.ByteString):
+    elif vtype == ua.VariantType.ByteString:
         val = string.encode("utf-8")
     elif vtype in (ua.VariantType.NodeId, ua.VariantType.ExpandedNodeId):
         val = ua.NodeId.from_string(string)

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -380,3 +380,17 @@ class XmlTests(object):
         self.assertEqual(dim, node2.get_array_dimensions())
         self.assertEqual(nclass, node2.get_node_class())
         return node2
+
+    def test_xml_byte(self):
+        o = self.opc.nodes.objects.add_variable(2, "byte", 255, ua.VariantType.Byte)
+        dtype = o.get_data_type()
+        dv = o.get_data_value()
+
+        self.opc.export_xml([o], "export-byte.xml")
+        self.opc.delete_nodes([o])
+        new_nodes = self.opc.import_xml("export-byte.xml")
+        o2 = self.opc.get_node(new_nodes[0])
+
+        self.assertEqual(o, o2)
+        self.assertEqual(dtype, o2.get_data_type())
+        self.assertEqual(dv.Value, o2.get_data_value().Value)


### PR DESCRIPTION
The xml import for the type Byte is broken, fixed ua_utils.string_to_val for Byte and SByte.

Step to reproduce:
- Add  xml_test_byte to the xml test suite


**Backgound:**
The current implementation treat Byte as single byte version of a ByteString, but Byte is just a nummeric value limited to 255 values. The same story for SByte.

In the https://opcfoundation.org/UA/2008/02/Types.xsd the definition is:
```xml
  <xs:element name="Byte" nillable="true" type="xs:unsignedByte" />
```

Where ByteString is:
```xml
  <xs:element name="ByteString" nillable="true" type="xs:base64Binary" />
```  

`xs:unsignedByte` is just a nummreic value without encoding, see for more info https://www.w3schools.com/xml/schema_dtypes_numeric.asp.