### PR TITLE
iterate over items in make_aspace_shelf

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -522,7 +522,7 @@ class AddressSpace(object):
         Note: Intended for slow devices, such as Raspberry Pi, to greatly improve start up time
         """
         s = shelve.open(path, "n", protocol=pickle.HIGHEST_PROTOCOL)
-        for nodeid, ndata in self._nodes.keys():
+        for nodeid, ndata in self._nodes.items():
             s[nodeid.to_string()] = ndata
         s.close()
 


### PR DESCRIPTION
`make_aspace_shelf` fails with `TypeError: 'NodeId' object is not iterable`