### PR TITLE
support IntEnum with Variant guess type

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -807,6 +807,8 @@ class Variant(FrozenClass):
             return VariantType.Boolean
         elif isinstance(val, float):
             return VariantType.Double
+        elif isinstance(val, IntEnum):
+            return VariantType.Int32
         elif isinstance(val, int):
             return VariantType.Int64
         elif type(val) in (str, unicode):

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -717,4 +717,7 @@ class CommonTests(object):
         for dt, vdt in test_data.items():
             self.assertEqual(ua_utils.data_type_to_variant_type(self.opc.get_node(ua.NodeId(dt))), vdt)
 
-
+    def test_variant_intenum(self):
+        ase = ua.AxisScaleEnumeration(ua.AxisScaleEnumeration.Linear)  # Just pick an existing IntEnum class
+        vAse = ua.Variant(ase)
+        self.assertEqual(vAse.VariantType, ua.VariantType.Int32)


### PR DESCRIPTION
Based on discussion in #426:
Support correct VariantType for node.set_value in case of an IntEnum.
