### PR TITLE
Fix codegeneration list of localized text

### DIFF
--- a/opcua/server/standard_address_space/standard_address_space_part11.py
+++ b/opcua/server/standard_address_space/standard_address_space_part11.py
@@ -2076,7 +2076,7 @@ def create_standard_address_space_Part11(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['AbsoluteValue', 'PercentOfValue', 'PercentOfRange', 'PercentOfEURange', 'Unknown'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("AbsoluteValue"),ua.LocalizedText("PercentOfValue"),ua.LocalizedText("PercentOfRange"),ua.LocalizedText("PercentOfEURange"),ua.LocalizedText("Unknown")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])

--- a/opcua/server/standard_address_space/standard_address_space_part3.py
+++ b/opcua/server/standard_address_space/standard_address_space_part3.py
@@ -39,7 +39,7 @@ def create_standard_address_space_Part3(server):
     node.BrowseName = ua.QualifiedName.from_string("BaseDataType")
     node.NodeClass = ua.NodeClass.DataType
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that can have any valid DataType.'")
+    attrs.Description = ua.LocalizedText("Describes a value that can have any valid DataType.")
     attrs.DisplayName = ua.LocalizedText("BaseDataType")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -52,7 +52,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that can have any numeric DataType.'")
+    attrs.Description = ua.LocalizedText("Describes a value that can have any numeric DataType.")
     attrs.DisplayName = ua.LocalizedText("Number")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -65,7 +65,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=26")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that can have any integer DataType.'")
+    attrs.Description = ua.LocalizedText("Describes a value that can have any integer DataType.")
     attrs.DisplayName = ua.LocalizedText("Integer")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -78,7 +78,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=26")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that can have any unsigned integer DataType.'")
+    attrs.Description = ua.LocalizedText("Describes a value that can have any unsigned integer DataType.")
     attrs.DisplayName = ua.LocalizedText("UInteger")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -91,7 +91,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an enumerated DataType.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an enumerated DataType.")
     attrs.DisplayName = ua.LocalizedText("Enumeration")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -104,7 +104,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is either TRUE or FALSE.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is either TRUE or FALSE.")
     attrs.DisplayName = ua.LocalizedText("Boolean")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -116,7 +116,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=27")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between -128 and 127.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between -128 and 127.")
     attrs.DisplayName = ua.LocalizedText("SByte")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -128,7 +128,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=28")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between 0 and 255.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between 0 and 255.")
     attrs.DisplayName = ua.LocalizedText("Byte")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -140,7 +140,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=27")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between ?32,768 and 32,767.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between ?32,768 and 32,767.")
     attrs.DisplayName = ua.LocalizedText("Int16")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -152,7 +152,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=28")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between 0 and 65535.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between 0 and 65535.")
     attrs.DisplayName = ua.LocalizedText("UInt16")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -164,7 +164,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=27")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between ?2,147,483,648  and 2,147,483,647.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between ?2,147,483,648  and 2,147,483,647.")
     attrs.DisplayName = ua.LocalizedText("Int32")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -176,7 +176,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=28")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between 0 and 4,294,967,295.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between 0 and 4,294,967,295.")
     attrs.DisplayName = ua.LocalizedText("UInt32")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -188,7 +188,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=27")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between ?9,223,372,036,854,775,808 and 9,223,372,036,854,775,807.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between ?9,223,372,036,854,775,808 and 9,223,372,036,854,775,807.")
     attrs.DisplayName = ua.LocalizedText("Int64")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -200,7 +200,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=28")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an integer between 0 and 18,446,744,073,709,551,615.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an integer between 0 and 18,446,744,073,709,551,615.")
     attrs.DisplayName = ua.LocalizedText("UInt64")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -212,7 +212,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=26")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an IEEE 754-1985 single precision floating point number.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an IEEE 754-1985 single precision floating point number.")
     attrs.DisplayName = ua.LocalizedText("Float")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -224,7 +224,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=26")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an IEEE 754-1985 double precision floating point number.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an IEEE 754-1985 double precision floating point number.")
     attrs.DisplayName = ua.LocalizedText("Double")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -236,7 +236,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a sequence of printable Unicode characters.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a sequence of printable Unicode characters.")
     attrs.DisplayName = ua.LocalizedText("String")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -248,7 +248,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a Gregorian calender date and time.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a Gregorian calender date and time.")
     attrs.DisplayName = ua.LocalizedText("DateTime")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -260,7 +260,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a 128-bit globally unique identifier.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a 128-bit globally unique identifier.")
     attrs.DisplayName = ua.LocalizedText("Guid")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -272,7 +272,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a sequence of bytes.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a sequence of bytes.")
     attrs.DisplayName = ua.LocalizedText("ByteString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -284,7 +284,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an XML element.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an XML element.")
     attrs.DisplayName = ua.LocalizedText("XmlElement")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -296,7 +296,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an identifier for a node within a Server address space.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an identifier for a node within a Server address space.")
     attrs.DisplayName = ua.LocalizedText("NodeId")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -308,7 +308,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a name qualified by a namespace.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a name qualified by a namespace.")
     attrs.DisplayName = ua.LocalizedText("QualifiedName")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -320,7 +320,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is human readable Unicode text with a locale identifier.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is human readable Unicode text with a locale identifier.")
     attrs.DisplayName = ua.LocalizedText("LocalizedText")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -332,7 +332,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is any type of structure that can be described with a data encoding.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is any type of structure that can be described with a data encoding.")
     attrs.DisplayName = ua.LocalizedText("Structure")
     attrs.IsAbstract = True
     node.NodeAttributes = attrs
@@ -345,7 +345,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=15")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an image encoded as a string of bytes.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an image encoded as a string of bytes.")
     attrs.DisplayName = ua.LocalizedText("Image")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -357,7 +357,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=26")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a 128-bit decimal value.'")
+    attrs.Description = ua.LocalizedText("Describes a 128-bit decimal value.")
     attrs.DisplayName = ua.LocalizedText("Decimal128")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -605,7 +605,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that specifies the significance of the BrowseName for an instance declaration.'")
+    attrs.Description = ua.LocalizedText("Describes a value that specifies the significance of the BrowseName for an instance declaration.")
     attrs.DisplayName = ua.LocalizedText("NamingRuleType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -631,19 +631,19 @@ def create_standard_address_space_Part3(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The BrowseName must appear in all instances of the type.'
-    extobj.DisplayName.Text = b'Mandatory'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'Mandatory'
+    extobj.Description.Text = b'The BrowseName must appear in all instances of the type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The BrowseName may appear in an instance of the type.'
-    extobj.DisplayName.Text = b'Optional'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'Optional'
+    extobj.Description.Text = b'The BrowseName may appear in an instance of the type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The modelling rule defines a constraint and the BrowseName is not used in an instance of the type.'
-    extobj.DisplayName.Text = b'Constraint'
     extobj.Value = 3
+    extobj.DisplayName.Text = b'Constraint'
+    extobj.Description.Text = b'The modelling rule defines a constraint and the BrowseName is not used in an instance of the type.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -861,7 +861,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=30")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An image encoded in BMP format.'")
+    attrs.Description = ua.LocalizedText("An image encoded in BMP format.")
     attrs.DisplayName = ua.LocalizedText("ImageBMP")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -873,7 +873,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=30")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An image encoded in GIF format.'")
+    attrs.Description = ua.LocalizedText("An image encoded in GIF format.")
     attrs.DisplayName = ua.LocalizedText("ImageGIF")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -885,7 +885,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=30")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An image encoded in JPEG format.'")
+    attrs.Description = ua.LocalizedText("An image encoded in JPEG format.")
     attrs.DisplayName = ua.LocalizedText("ImageJPG")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -897,7 +897,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=30")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An image encoded in PNG format.'")
+    attrs.Description = ua.LocalizedText("An image encoded in PNG format.")
     attrs.DisplayName = ua.LocalizedText("ImagePNG")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -909,7 +909,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The type of identifier used in a node id.'")
+    attrs.Description = ua.LocalizedText("The type of identifier used in a node id.")
     attrs.DisplayName = ua.LocalizedText("IdType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -933,7 +933,7 @@ def create_standard_address_space_Part3(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Numeric', 'String', 'Guid', 'Opaque'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Numeric"),ua.LocalizedText("String"),ua.LocalizedText("Guid"),ua.LocalizedText("Opaque")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -954,7 +954,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A mask specifying the class of the node.'")
+    attrs.Description = ua.LocalizedText("A mask specifying the class of the node.")
     attrs.DisplayName = ua.LocalizedText("NodeClass")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -980,49 +980,49 @@ def create_standard_address_space_Part3(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'No classes are selected.'
-    extobj.DisplayName.Text = b'Unspecified'
     extobj.Value = 0
+    extobj.DisplayName.Text = b'Unspecified'
+    extobj.Description.Text = b'No classes are selected.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is an object.'
-    extobj.DisplayName.Text = b'Object'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'Object'
+    extobj.Description.Text = b'The node is an object.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is a variable.'
-    extobj.DisplayName.Text = b'Variable'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'Variable'
+    extobj.Description.Text = b'The node is a variable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is a method.'
-    extobj.DisplayName.Text = b'Method'
     extobj.Value = 4
+    extobj.DisplayName.Text = b'Method'
+    extobj.Description.Text = b'The node is a method.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is an object type.'
-    extobj.DisplayName.Text = b'ObjectType'
     extobj.Value = 8
+    extobj.DisplayName.Text = b'ObjectType'
+    extobj.Description.Text = b'The node is an object type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is an variable type.'
-    extobj.DisplayName.Text = b'VariableType'
     extobj.Value = 16
+    extobj.DisplayName.Text = b'VariableType'
+    extobj.Description.Text = b'The node is an variable type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is a reference type.'
-    extobj.DisplayName.Text = b'ReferenceType'
     extobj.Value = 32
+    extobj.DisplayName.Text = b'ReferenceType'
+    extobj.Description.Text = b'The node is a reference type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is a data type.'
-    extobj.DisplayName.Text = b'DataType'
     extobj.Value = 64
+    extobj.DisplayName.Text = b'DataType'
+    extobj.Description.Text = b'The node is a data type.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node is a view.'
-    extobj.DisplayName.Text = b'View'
     extobj.Value = 128
+    extobj.DisplayName.Text = b'View'
+    extobj.Description.Text = b'The node is a view.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1045,7 +1045,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An argument for a method.'")
+    attrs.Description = ua.LocalizedText("An argument for a method.")
     attrs.DisplayName = ua.LocalizedText("Argument")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1057,7 +1057,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A mapping between a value of an enumerated type and a name and description.'")
+    attrs.Description = ua.LocalizedText("A mapping between a value of an enumerated type and a name and description.")
     attrs.DisplayName = ua.LocalizedText("EnumValueType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1069,7 +1069,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'This abstract Structured DataType is the base DataType for all DataTypes representing a bit mask.'")
+    attrs.Description = ua.LocalizedText("This abstract Structured DataType is the base DataType for all DataTypes representing a bit mask.")
     attrs.DisplayName = ua.LocalizedText("OptionSet")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1081,7 +1081,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'This abstract DataType is the base DataType for all union DataTypes.'")
+    attrs.Description = ua.LocalizedText("This abstract DataType is the base DataType for all union DataTypes.")
     attrs.DisplayName = ua.LocalizedText("Union")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1093,7 +1093,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A string normalized based on the rules in the unicode specification.'")
+    attrs.Description = ua.LocalizedText("A string normalized based on the rules in the unicode specification.")
     attrs.DisplayName = ua.LocalizedText("NormalizedString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1105,7 +1105,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An arbitraty numeric value.'")
+    attrs.Description = ua.LocalizedText("An arbitraty numeric value.")
     attrs.DisplayName = ua.LocalizedText("DecimalString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1117,7 +1117,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A period of time formatted as defined in ISO 8601-2000.'")
+    attrs.Description = ua.LocalizedText("A period of time formatted as defined in ISO 8601-2000.")
     attrs.DisplayName = ua.LocalizedText("DurationString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1129,7 +1129,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A time formatted as defined in ISO 8601-2000.'")
+    attrs.Description = ua.LocalizedText("A time formatted as defined in ISO 8601-2000.")
     attrs.DisplayName = ua.LocalizedText("TimeString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1141,7 +1141,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A date formatted as defined in ISO 8601-2000.'")
+    attrs.Description = ua.LocalizedText("A date formatted as defined in ISO 8601-2000.")
     attrs.DisplayName = ua.LocalizedText("DateString")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1153,7 +1153,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=11")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A period of time measured in milliseconds.'")
+    attrs.Description = ua.LocalizedText("A period of time measured in milliseconds.")
     attrs.DisplayName = ua.LocalizedText("Duration")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1165,7 +1165,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=13")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A date/time value specified in Universal Coordinated Time (UTC).'")
+    attrs.Description = ua.LocalizedText("A date/time value specified in Universal Coordinated Time (UTC).")
     attrs.DisplayName = ua.LocalizedText("UtcTime")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1177,7 +1177,7 @@ def create_standard_address_space_Part3(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An identifier for a user locale.'")
+    attrs.Description = ua.LocalizedText("An identifier for a user locale.")
     attrs.DisplayName = ua.LocalizedText("LocaleId")
     node.NodeAttributes = attrs
     server.add_nodes([node])

--- a/opcua/server/standard_address_space/standard_address_space_part4.py
+++ b/opcua/server/standard_address_space/standard_address_space_part4.py
@@ -17,7 +17,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is an absolute identifier for a node.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is an absolute identifier for a node.")
     attrs.DisplayName = ua.LocalizedText("ExpandedNodeId")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -29,7 +29,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a code representing the outcome of an operation by a Server.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a code representing the outcome of an operation by a Server.")
     attrs.DisplayName = ua.LocalizedText("StatusCode")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -41,7 +41,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a structure containing a value, a status code and timestamps.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a structure containing a value, a status code and timestamps.")
     attrs.DisplayName = ua.LocalizedText("DataValue")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -53,7 +53,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=24")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a value that is a structure containing diagnostics associated with a StatusCode.'")
+    attrs.Description = ua.LocalizedText("Describes a value that is a structure containing diagnostics associated with a StatusCode.")
     attrs.DisplayName = ua.LocalizedText("DiagnosticInfo")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -65,7 +65,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=7")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A numeric identifier for an object.'")
+    attrs.Description = ua.LocalizedText("A numeric identifier for an object.")
     attrs.DisplayName = ua.LocalizedText("IntegerId")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -77,7 +77,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The types of applications.'")
+    attrs.Description = ua.LocalizedText("The types of applications.")
     attrs.DisplayName = ua.LocalizedText("ApplicationType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -101,7 +101,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Server', 'Client', 'ClientAndServer', 'DiscoveryServer'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Server"),ua.LocalizedText("Client"),ua.LocalizedText("ClientAndServer"),ua.LocalizedText("DiscoveryServer")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -122,7 +122,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes an application and how to find it.'")
+    attrs.Description = ua.LocalizedText("Describes an application and how to find it.")
     attrs.DisplayName = ua.LocalizedText("ApplicationDescription")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -145,7 +145,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=15")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A certificate for an instance of an application.'")
+    attrs.Description = ua.LocalizedText("A certificate for an instance of an application.")
     attrs.DisplayName = ua.LocalizedText("ApplicationInstanceCertificate")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -157,7 +157,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The type of security to use on a message.'")
+    attrs.Description = ua.LocalizedText("The type of security to use on a message.")
     attrs.DisplayName = ua.LocalizedText("MessageSecurityMode")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -181,7 +181,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Invalid', 'None', 'Sign', 'SignAndEncrypt'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Invalid"),ua.LocalizedText("None"),ua.LocalizedText("Sign"),ua.LocalizedText("SignAndEncrypt")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -202,7 +202,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The possible user token types.'")
+    attrs.Description = ua.LocalizedText("The possible user token types.")
     attrs.DisplayName = ua.LocalizedText("UserTokenType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -226,7 +226,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Anonymous', 'UserName', 'Certificate', 'IssuedToken', 'Kerberos'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Anonymous"),ua.LocalizedText("UserName"),ua.LocalizedText("Certificate"),ua.LocalizedText("IssuedToken"),ua.LocalizedText("Kerberos")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -247,7 +247,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Describes a user token that can be used with a server.'")
+    attrs.Description = ua.LocalizedText("Describes a user token that can be used with a server.")
     attrs.DisplayName = ua.LocalizedText("UserTokenPolicy")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -259,7 +259,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The description of a endpoint that can be used to access a server.'")
+    attrs.Description = ua.LocalizedText("The description of a endpoint that can be used to access a server.")
     attrs.DisplayName = ua.LocalizedText("EndpointDescription")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -271,7 +271,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The information required to register a server with a discovery server.'")
+    attrs.Description = ua.LocalizedText("The information required to register a server with a discovery server.")
     attrs.DisplayName = ua.LocalizedText("RegisteredServer")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -283,7 +283,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A base type for discovery configuration information.'")
+    attrs.Description = ua.LocalizedText("A base type for discovery configuration information.")
     attrs.DisplayName = ua.LocalizedText("DiscoveryConfiguration")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -295,7 +295,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12890")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The discovery information needed for mDNS registration.'")
+    attrs.Description = ua.LocalizedText("The discovery information needed for mDNS registration.")
     attrs.DisplayName = ua.LocalizedText("MdnsDiscoveryConfiguration")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -307,7 +307,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Indicates whether a token if being created or renewed.'")
+    attrs.Description = ua.LocalizedText("Indicates whether a token if being created or renewed.")
     attrs.DisplayName = ua.LocalizedText("SecurityTokenRequestType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -331,7 +331,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Issue', 'Renew'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Issue"),ua.LocalizedText("Renew")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -352,7 +352,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A software certificate with a digital signature.'")
+    attrs.Description = ua.LocalizedText("A software certificate with a digital signature.")
     attrs.DisplayName = ua.LocalizedText("SignedSoftwareCertificate")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -364,7 +364,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=17")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A unique identifier for a session used to authenticate requests.'")
+    attrs.Description = ua.LocalizedText("A unique identifier for a session used to authenticate requests.")
     attrs.DisplayName = ua.LocalizedText("SessionAuthenticationToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -376,7 +376,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A base type for a user identity token.'")
+    attrs.Description = ua.LocalizedText("A base type for a user identity token.")
     attrs.DisplayName = ua.LocalizedText("UserIdentityToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -388,7 +388,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=316")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A token representing an anonymous user.'")
+    attrs.Description = ua.LocalizedText("A token representing an anonymous user.")
     attrs.DisplayName = ua.LocalizedText("AnonymousIdentityToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -400,7 +400,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=316")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A token representing a user identified by a user name and password.'")
+    attrs.Description = ua.LocalizedText("A token representing a user identified by a user name and password.")
     attrs.DisplayName = ua.LocalizedText("UserNameIdentityToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -412,7 +412,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=316")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A token representing a user identified by an X509 certificate.'")
+    attrs.Description = ua.LocalizedText("A token representing a user identified by an X509 certificate.")
     attrs.DisplayName = ua.LocalizedText("X509IdentityToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -435,7 +435,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=316")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A token representing a user identified by a WS-Security XML token.'")
+    attrs.Description = ua.LocalizedText("A token representing a user identified by a WS-Security XML token.")
     attrs.DisplayName = ua.LocalizedText("IssuedIdentityToken")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -447,7 +447,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'The bits used to specify default attributes for a new node.'")
+    attrs.Description = ua.LocalizedText("The bits used to specify default attributes for a new node.")
     attrs.DisplayName = ua.LocalizedText("NodeAttributesMask")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -473,164 +473,164 @@ def create_standard_address_space_Part4(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'No attribuites provided.'
-    extobj.DisplayName.Text = b'None'
     extobj.Value = 0
+    extobj.DisplayName.Text = b'None'
+    extobj.Description.Text = b'No attribuites provided.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The access level attribute is specified.'
-    extobj.DisplayName.Text = b'AccessLevel'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'AccessLevel'
+    extobj.Description.Text = b'The access level attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The array dimensions attribute is specified.'
-    extobj.DisplayName.Text = b'ArrayDimensions'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'ArrayDimensions'
+    extobj.Description.Text = b'The array dimensions attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The browse name attribute is specified.'
-    extobj.DisplayName.Text = b'BrowseName'
     extobj.Value = 4
+    extobj.DisplayName.Text = b'BrowseName'
+    extobj.Description.Text = b'The browse name attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The contains no loops attribute is specified.'
-    extobj.DisplayName.Text = b'ContainsNoLoops'
     extobj.Value = 8
+    extobj.DisplayName.Text = b'ContainsNoLoops'
+    extobj.Description.Text = b'The contains no loops attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The data type attribute is specified.'
-    extobj.DisplayName.Text = b'DataType'
     extobj.Value = 16
+    extobj.DisplayName.Text = b'DataType'
+    extobj.Description.Text = b'The data type attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The description attribute is specified.'
-    extobj.DisplayName.Text = b'Description'
     extobj.Value = 32
+    extobj.DisplayName.Text = b'Description'
+    extobj.Description.Text = b'The description attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The display name attribute is specified.'
-    extobj.DisplayName.Text = b'DisplayName'
     extobj.Value = 64
+    extobj.DisplayName.Text = b'DisplayName'
+    extobj.Description.Text = b'The display name attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The event notifier attribute is specified.'
-    extobj.DisplayName.Text = b'EventNotifier'
     extobj.Value = 128
+    extobj.DisplayName.Text = b'EventNotifier'
+    extobj.Description.Text = b'The event notifier attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The executable attribute is specified.'
-    extobj.DisplayName.Text = b'Executable'
     extobj.Value = 256
+    extobj.DisplayName.Text = b'Executable'
+    extobj.Description.Text = b'The executable attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The historizing attribute is specified.'
-    extobj.DisplayName.Text = b'Historizing'
     extobj.Value = 512
+    extobj.DisplayName.Text = b'Historizing'
+    extobj.Description.Text = b'The historizing attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The inverse name attribute is specified.'
-    extobj.DisplayName.Text = b'InverseName'
     extobj.Value = 1024
+    extobj.DisplayName.Text = b'InverseName'
+    extobj.Description.Text = b'The inverse name attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The is abstract attribute is specified.'
-    extobj.DisplayName.Text = b'IsAbstract'
     extobj.Value = 2048
+    extobj.DisplayName.Text = b'IsAbstract'
+    extobj.Description.Text = b'The is abstract attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The minimum sampling interval attribute is specified.'
-    extobj.DisplayName.Text = b'MinimumSamplingInterval'
     extobj.Value = 4096
+    extobj.DisplayName.Text = b'MinimumSamplingInterval'
+    extobj.Description.Text = b'The minimum sampling interval attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node class attribute is specified.'
-    extobj.DisplayName.Text = b'NodeClass'
     extobj.Value = 8192
+    extobj.DisplayName.Text = b'NodeClass'
+    extobj.Description.Text = b'The node class attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node id attribute is specified.'
-    extobj.DisplayName.Text = b'NodeId'
     extobj.Value = 16384
+    extobj.DisplayName.Text = b'NodeId'
+    extobj.Description.Text = b'The node id attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The symmetric attribute is specified.'
-    extobj.DisplayName.Text = b'Symmetric'
     extobj.Value = 32768
+    extobj.DisplayName.Text = b'Symmetric'
+    extobj.Description.Text = b'The symmetric attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user access level attribute is specified.'
-    extobj.DisplayName.Text = b'UserAccessLevel'
     extobj.Value = 65536
+    extobj.DisplayName.Text = b'UserAccessLevel'
+    extobj.Description.Text = b'The user access level attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user executable attribute is specified.'
-    extobj.DisplayName.Text = b'UserExecutable'
     extobj.Value = 131072
+    extobj.DisplayName.Text = b'UserExecutable'
+    extobj.Description.Text = b'The user executable attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user write mask attribute is specified.'
-    extobj.DisplayName.Text = b'UserWriteMask'
     extobj.Value = 262144
+    extobj.DisplayName.Text = b'UserWriteMask'
+    extobj.Description.Text = b'The user write mask attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The value rank attribute is specified.'
-    extobj.DisplayName.Text = b'ValueRank'
     extobj.Value = 524288
+    extobj.DisplayName.Text = b'ValueRank'
+    extobj.Description.Text = b'The value rank attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The write mask attribute is specified.'
-    extobj.DisplayName.Text = b'WriteMask'
     extobj.Value = 1048576
+    extobj.DisplayName.Text = b'WriteMask'
+    extobj.Description.Text = b'The write mask attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The value attribute is specified.'
-    extobj.DisplayName.Text = b'Value'
     extobj.Value = 2097152
+    extobj.DisplayName.Text = b'Value'
+    extobj.Description.Text = b'The value attribute is specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All attributes are specified.'
-    extobj.DisplayName.Text = b'All'
     extobj.Value = 4194303
+    extobj.DisplayName.Text = b'All'
+    extobj.Description.Text = b'All attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All base attributes are specified.'
-    extobj.DisplayName.Text = b'BaseNode'
     extobj.Value = 1335396
+    extobj.DisplayName.Text = b'BaseNode'
+    extobj.Description.Text = b'All base attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All object attributes are specified.'
-    extobj.DisplayName.Text = b'Object'
     extobj.Value = 1335524
+    extobj.DisplayName.Text = b'Object'
+    extobj.Description.Text = b'All object attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All object type or data type attributes are specified.'
-    extobj.DisplayName.Text = b'ObjectTypeOrDataType'
     extobj.Value = 1337444
+    extobj.DisplayName.Text = b'ObjectTypeOrDataType'
+    extobj.Description.Text = b'All object type or data type attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All variable attributes are specified.'
-    extobj.DisplayName.Text = b'Variable'
     extobj.Value = 4026999
+    extobj.DisplayName.Text = b'Variable'
+    extobj.Description.Text = b'All variable attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All variable type attributes are specified.'
-    extobj.DisplayName.Text = b'VariableType'
     extobj.Value = 3958902
+    extobj.DisplayName.Text = b'VariableType'
+    extobj.Description.Text = b'All variable type attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All method attributes are specified.'
-    extobj.DisplayName.Text = b'Method'
     extobj.Value = 1466724
+    extobj.DisplayName.Text = b'Method'
+    extobj.Description.Text = b'All method attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All reference type attributes are specified.'
-    extobj.DisplayName.Text = b'ReferenceType'
     extobj.Value = 1371236
+    extobj.DisplayName.Text = b'ReferenceType'
+    extobj.Description.Text = b'All reference type attributes are specified.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'All view attributes are specified.'
-    extobj.DisplayName.Text = b'View'
     extobj.Value = 1335532
+    extobj.DisplayName.Text = b'View'
+    extobj.Description.Text = b'All view attributes are specified.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -653,7 +653,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A request to add a node to the server address space.'")
+    attrs.Description = ua.LocalizedText("A request to add a node to the server address space.")
     attrs.DisplayName = ua.LocalizedText("AddNodesItem")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -665,7 +665,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A request to add a reference to the server address space.'")
+    attrs.Description = ua.LocalizedText("A request to add a reference to the server address space.")
     attrs.DisplayName = ua.LocalizedText("AddReferencesItem")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -677,7 +677,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A request to delete a node to the server address space.'")
+    attrs.Description = ua.LocalizedText("A request to delete a node to the server address space.")
     attrs.DisplayName = ua.LocalizedText("DeleteNodesItem")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -689,7 +689,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A request to delete a node from the server address space.'")
+    attrs.Description = ua.LocalizedText("A request to delete a node from the server address space.")
     attrs.DisplayName = ua.LocalizedText("DeleteReferencesItem")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -701,7 +701,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=29")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Define bits used to indicate which attributes are writable.'")
+    attrs.Description = ua.LocalizedText("Define bits used to indicate which attributes are writable.")
     attrs.DisplayName = ua.LocalizedText("AttributeWriteMask")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -727,119 +727,119 @@ def create_standard_address_space_Part4(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'No attributes are writable.'
-    extobj.DisplayName.Text = b'None'
     extobj.Value = 0
+    extobj.DisplayName.Text = b'None'
+    extobj.Description.Text = b'No attributes are writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The access level attribute is writable.'
-    extobj.DisplayName.Text = b'AccessLevel'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'AccessLevel'
+    extobj.Description.Text = b'The access level attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The array dimensions attribute is writable.'
-    extobj.DisplayName.Text = b'ArrayDimensions'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'ArrayDimensions'
+    extobj.Description.Text = b'The array dimensions attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The browse name attribute is writable.'
-    extobj.DisplayName.Text = b'BrowseName'
     extobj.Value = 4
+    extobj.DisplayName.Text = b'BrowseName'
+    extobj.Description.Text = b'The browse name attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The contains no loops attribute is writable.'
-    extobj.DisplayName.Text = b'ContainsNoLoops'
     extobj.Value = 8
+    extobj.DisplayName.Text = b'ContainsNoLoops'
+    extobj.Description.Text = b'The contains no loops attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The data type attribute is writable.'
-    extobj.DisplayName.Text = b'DataType'
     extobj.Value = 16
+    extobj.DisplayName.Text = b'DataType'
+    extobj.Description.Text = b'The data type attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The description attribute is writable.'
-    extobj.DisplayName.Text = b'Description'
     extobj.Value = 32
+    extobj.DisplayName.Text = b'Description'
+    extobj.Description.Text = b'The description attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The display name attribute is writable.'
-    extobj.DisplayName.Text = b'DisplayName'
     extobj.Value = 64
+    extobj.DisplayName.Text = b'DisplayName'
+    extobj.Description.Text = b'The display name attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The event notifier attribute is writable.'
-    extobj.DisplayName.Text = b'EventNotifier'
     extobj.Value = 128
+    extobj.DisplayName.Text = b'EventNotifier'
+    extobj.Description.Text = b'The event notifier attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The executable attribute is writable.'
-    extobj.DisplayName.Text = b'Executable'
     extobj.Value = 256
+    extobj.DisplayName.Text = b'Executable'
+    extobj.Description.Text = b'The executable attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The historizing attribute is writable.'
-    extobj.DisplayName.Text = b'Historizing'
     extobj.Value = 512
+    extobj.DisplayName.Text = b'Historizing'
+    extobj.Description.Text = b'The historizing attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The inverse name attribute is writable.'
-    extobj.DisplayName.Text = b'InverseName'
     extobj.Value = 1024
+    extobj.DisplayName.Text = b'InverseName'
+    extobj.Description.Text = b'The inverse name attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The is abstract attribute is writable.'
-    extobj.DisplayName.Text = b'IsAbstract'
     extobj.Value = 2048
+    extobj.DisplayName.Text = b'IsAbstract'
+    extobj.Description.Text = b'The is abstract attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The minimum sampling interval attribute is writable.'
-    extobj.DisplayName.Text = b'MinimumSamplingInterval'
     extobj.Value = 4096
+    extobj.DisplayName.Text = b'MinimumSamplingInterval'
+    extobj.Description.Text = b'The minimum sampling interval attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node class attribute is writable.'
-    extobj.DisplayName.Text = b'NodeClass'
     extobj.Value = 8192
+    extobj.DisplayName.Text = b'NodeClass'
+    extobj.Description.Text = b'The node class attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The node id attribute is writable.'
-    extobj.DisplayName.Text = b'NodeId'
     extobj.Value = 16384
+    extobj.DisplayName.Text = b'NodeId'
+    extobj.Description.Text = b'The node id attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The symmetric attribute is writable.'
-    extobj.DisplayName.Text = b'Symmetric'
     extobj.Value = 32768
+    extobj.DisplayName.Text = b'Symmetric'
+    extobj.Description.Text = b'The symmetric attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user access level attribute is writable.'
-    extobj.DisplayName.Text = b'UserAccessLevel'
     extobj.Value = 65536
+    extobj.DisplayName.Text = b'UserAccessLevel'
+    extobj.Description.Text = b'The user access level attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user executable attribute is writable.'
-    extobj.DisplayName.Text = b'UserExecutable'
     extobj.Value = 131072
+    extobj.DisplayName.Text = b'UserExecutable'
+    extobj.Description.Text = b'The user executable attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The user write mask attribute is writable.'
-    extobj.DisplayName.Text = b'UserWriteMask'
     extobj.Value = 262144
+    extobj.DisplayName.Text = b'UserWriteMask'
+    extobj.Description.Text = b'The user write mask attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The value rank attribute is writable.'
-    extobj.DisplayName.Text = b'ValueRank'
     extobj.Value = 524288
+    extobj.DisplayName.Text = b'ValueRank'
+    extobj.Description.Text = b'The value rank attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The write mask attribute is writable.'
-    extobj.DisplayName.Text = b'WriteMask'
     extobj.Value = 1048576
+    extobj.DisplayName.Text = b'WriteMask'
+    extobj.Description.Text = b'The write mask attribute is writable.'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.Description.Text = b'The value attribute is writable.'
-    extobj.DisplayName.Text = b'ValueForVariableType'
     extobj.Value = 2097152
+    extobj.DisplayName.Text = b'ValueForVariableType'
+    extobj.Description.Text = b'The value attribute is writable.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -862,7 +862,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=15")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An identifier for a suspended query or browse operation.'")
+    attrs.Description = ua.LocalizedText("An identifier for a suspended query or browse operation.")
     attrs.DisplayName = ua.LocalizedText("ContinuationPoint")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -874,7 +874,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'An element in a relative path.'")
+    attrs.Description = ua.LocalizedText("An element in a relative path.")
     attrs.DisplayName = ua.LocalizedText("RelativePathElement")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -886,7 +886,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=22")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A relative path constructed from reference types and browse names.'")
+    attrs.Description = ua.LocalizedText("A relative path constructed from reference types and browse names.")
     attrs.DisplayName = ua.LocalizedText("RelativePath")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -898,7 +898,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=7")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A monotonically increasing value.'")
+    attrs.Description = ua.LocalizedText("A monotonically increasing value.")
     attrs.DisplayName = ua.LocalizedText("Counter")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -910,7 +910,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'Specifies a range of array indexes.'")
+    attrs.Description = ua.LocalizedText("Specifies a range of array indexes.")
     attrs.DisplayName = ua.LocalizedText("NumericRange")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -922,7 +922,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=12")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A time value specified as HH:MM:SS.SSS.'")
+    attrs.Description = ua.LocalizedText("A time value specified as HH:MM:SS.SSS.")
     attrs.DisplayName = ua.LocalizedText("Time")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -934,7 +934,7 @@ def create_standard_address_space_Part4(server):
     node.ParentNodeId = ua.NodeId.from_string("i=13")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A date value.'")
+    attrs.Description = ua.LocalizedText("A date value.")
     attrs.DisplayName = ua.LocalizedText("Date")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -980,7 +980,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Untested', 'Partial', 'SelfTested', 'Certified'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Untested"),ua.LocalizedText("Partial"),ua.LocalizedText("SelfTested"),ua.LocalizedText("Certified")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1046,7 +1046,7 @@ def create_standard_address_space_Part4(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Equals', 'IsNull', 'GreaterThan', 'LessThan', 'GreaterThanOrEqual', 'LessThanOrEqual', 'Like', 'Not', 'Between', 'InList', 'And', 'Or', 'Cast', 'InView', 'OfType', 'RelatedTo', 'BitwiseAnd', 'BitwiseOr'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Equals"),ua.LocalizedText("IsNull"),ua.LocalizedText("GreaterThan"),ua.LocalizedText("LessThan"),ua.LocalizedText("GreaterThanOrEqual"),ua.LocalizedText("LessThanOrEqual"),ua.LocalizedText("Like"),ua.LocalizedText("Not"),ua.LocalizedText("Between"),ua.LocalizedText("InList"),ua.LocalizedText("And"),ua.LocalizedText("Or"),ua.LocalizedText("Cast"),ua.LocalizedText("InView"),ua.LocalizedText("OfType"),ua.LocalizedText("RelatedTo"),ua.LocalizedText("BitwiseAnd"),ua.LocalizedText("BitwiseOr")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -1180,20 +1180,20 @@ def create_standard_address_space_Part4(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Insert'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'Insert'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Replace'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'Replace'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Update'
     extobj.Value = 3
+    extobj.DisplayName.Text = b'Update'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Delete'
     extobj.Value = 4
+    extobj.DisplayName.Text = b'Delete'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1241,20 +1241,20 @@ def create_standard_address_space_Part4(server):
     attrs.DataType = ua.NodeId.from_string("i=7594")
     value = []
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Insert'
     extobj.Value = 1
+    extobj.DisplayName.Text = b'Insert'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Replace'
     extobj.Value = 2
+    extobj.DisplayName.Text = b'Replace'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Update'
     extobj.Value = 3
+    extobj.DisplayName.Text = b'Update'
     value.append(extobj)
     extobj = ua.EnumValueType()
-    extobj.DisplayName.Text = b'Remove'
     extobj.Value = 4
+    extobj.DisplayName.Text = b'Remove'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1

--- a/opcua/server/standard_address_space/standard_address_space_part5.py
+++ b/opcua/server/standard_address_space/standard_address_space_part5.py
@@ -2425,8 +2425,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -2455,13 +2455,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'ServerHandles'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = 1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'ClientHandles'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = 1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -2517,8 +2517,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -2581,13 +2581,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'LifetimeInHours'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -2616,8 +2616,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'RevisedLifetimeInHours'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -2673,28 +2673,28 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=852")
     extobj.Name = 'State'
+    extobj.DataType = ua.NodeId.from_string("i=852")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=13")
     extobj.Name = 'EstimatedReturnTime'
+    extobj.DataType = ua.NodeId.from_string("i=13")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SecondsTillShutdown'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.Name = 'Reason'
+    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'Restart'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8047,8 +8047,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.Name = 'Mode'
+    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8077,8 +8077,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8134,8 +8134,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8198,13 +8198,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.Name = 'Length'
+    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8233,8 +8233,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8290,13 +8290,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8359,8 +8359,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8389,8 +8389,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8446,13 +8446,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8621,8 +8621,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'DirectoryName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8651,8 +8651,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'DirectoryNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8715,13 +8715,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'FileName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'RequestFileOpen'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8750,13 +8750,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'FileNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8812,8 +8812,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'ObjectToDelete'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8876,23 +8876,23 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'ObjectToMoveOrCopy'
-    extobj.ValueRank = -1
-    value.append(extobj)
-    extobj = ua.Argument()
     extobj.DataType = ua.NodeId.from_string("i=17")
+    extobj.ValueRank = -1
+    value.append(extobj)
+    extobj = ua.Argument()
     extobj.Name = 'TargetDirectory'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'CreateCopy'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'NewName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -8921,8 +8921,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'NewNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9173,8 +9173,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.Name = 'Mode'
+    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9203,8 +9203,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9260,8 +9260,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9324,13 +9324,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.Name = 'Length'
+    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9359,8 +9359,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9416,13 +9416,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9485,8 +9485,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9515,8 +9515,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9572,13 +9572,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9641,8 +9641,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'DirectoryName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9671,8 +9671,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'DirectoryNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9735,13 +9735,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'FileName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'RequestFileOpen'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9770,13 +9770,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'FileNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9832,8 +9832,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'ObjectToDelete'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9896,23 +9896,23 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'ObjectToMoveOrCopy'
-    extobj.ValueRank = -1
-    value.append(extobj)
-    extobj = ua.Argument()
     extobj.DataType = ua.NodeId.from_string("i=17")
+    extobj.ValueRank = -1
+    value.append(extobj)
+    extobj = ua.Argument()
     extobj.Name = 'TargetDirectory'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'CreateCopy'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.Name = 'NewName'
+    extobj.DataType = ua.NodeId.from_string("i=12")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -9941,8 +9941,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.Name = 'NewNodeId'
+    extobj.DataType = ua.NodeId.from_string("i=17")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10476,8 +10476,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.Name = 'Mode'
+    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10506,8 +10506,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10563,8 +10563,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10627,13 +10627,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.Name = 'Length'
+    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10662,8 +10662,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10719,13 +10719,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10788,8 +10788,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10818,8 +10818,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -10875,13 +10875,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11401,8 +11401,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.Name = 'Mode'
+    extobj.DataType = ua.NodeId.from_string("i=3")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11431,8 +11431,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11488,8 +11488,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11552,13 +11552,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.Name = 'Length'
+    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11587,8 +11587,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11644,13 +11644,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'Data'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11713,8 +11713,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11743,8 +11743,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -11800,13 +11800,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'FileHandle'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.Name = 'Position'
+    extobj.DataType = ua.NodeId.from_string("i=9")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22020,8 +22020,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22041,13 +22041,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'ServerHandles'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = 1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'ClientHandles'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = 1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22087,8 +22087,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22135,13 +22135,13 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'LifetimeInHours'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22161,8 +22161,8 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'RevisedLifetimeInHours'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22202,28 +22202,28 @@ def create_standard_address_space_Part5(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=852")
     extobj.Name = 'State'
+    extobj.DataType = ua.NodeId.from_string("i=852")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=13")
     extobj.Name = 'EstimatedReturnTime'
+    extobj.DataType = ua.NodeId.from_string("i=13")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.Name = 'SecondsTillShutdown'
+    extobj.DataType = ua.NodeId.from_string("i=7")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.Name = 'Reason'
+    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.ValueRank = -1
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.Name = 'Restart'
+    extobj.DataType = ua.NodeId.from_string("i=1")
     extobj.ValueRank = -1
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
@@ -22238,7 +22238,7 @@ def create_standard_address_space_Part5(server):
     node.ParentNodeId = ua.NodeId.from_string("i=9")
     node.ReferenceTypeId = ua.NodeId.from_string("i=45")
     attrs = ua.DataTypeAttributes()
-    attrs.Description = ua.LocalizedText("b'A mask of 32 bits that can be updated individually by using the top 32 bits as a mask.'")
+    attrs.Description = ua.LocalizedText("A mask of 32 bits that can be updated individually by using the top 32 bits as a mask.")
     attrs.DisplayName = ua.LocalizedText("BitFieldMaskDataType")
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -23314,7 +23314,7 @@ def create_standard_address_space_Part5(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['None', 'Cold', 'Warm', 'Hot', 'Transparent', 'HotAndMirrored'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("None"),ua.LocalizedText("Cold"),ua.LocalizedText("Warm"),ua.LocalizedText("Hot"),ua.LocalizedText("Transparent"),ua.LocalizedText("HotAndMirrored")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])
@@ -23358,7 +23358,7 @@ def create_standard_address_space_Part5(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Running', 'Failed', 'NoConfiguration', 'Suspended', 'Shutdown', 'Test', 'CommunicationFault', 'Unknown'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Running"),ua.LocalizedText("Failed"),ua.LocalizedText("NoConfiguration"),ua.LocalizedText("Suspended"),ua.LocalizedText("Shutdown"),ua.LocalizedText("Test"),ua.LocalizedText("CommunicationFault"),ua.LocalizedText("Unknown")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])

--- a/opcua/server/standard_address_space/standard_address_space_part8.py
+++ b/opcua/server/standard_address_space/standard_address_space_part8.py
@@ -950,7 +950,7 @@ def create_standard_address_space_Part8(server):
     attrs = ua.VariableAttributes()
     attrs.DisplayName = ua.LocalizedText("EnumStrings")
     attrs.DataType = ua.NodeId(ua.ObjectIds.LocalizedText)
-    attrs.Value = ua.Variant(['Linear', 'Log', 'Ln'], ua.VariantType.LocalizedText)
+    attrs.Value = [ua.LocalizedText("Linear"),ua.LocalizedText("Log"),ua.LocalizedText("Ln")]
     attrs.ValueRank = 1
     node.NodeAttributes = attrs
     server.add_nodes([node])

--- a/opcua/server/standard_address_space/standard_address_space_part9.py
+++ b/opcua/server/standard_address_space/standard_address_space_part9.py
@@ -905,16 +905,16 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the event to comment.'
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'EventId'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the event to comment.'
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.Description.Text = b'The comment to add to the condition.'
-    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.Name = 'Comment'
+    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The comment to add to the condition.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -976,10 +976,10 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the suscription to refresh.'
-    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the suscription to refresh.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1041,16 +1041,16 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the suscription to refresh.'
-    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.Name = 'SubscriptionId'
+    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the suscription to refresh.'
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the monitored item to refresh.'
-    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.Name = 'MonitoredItemId'
+    extobj.DataType = ua.NodeId.from_string("i=288")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the monitored item to refresh.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1470,10 +1470,10 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The response to the dialog condition.'
-    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.Name = 'SelectedResponse'
+    extobj.DataType = ua.NodeId.from_string("i=6")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The response to the dialog condition.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1817,16 +1817,16 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the event to comment.'
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'EventId'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the event to comment.'
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.Description.Text = b'The comment to add to the condition.'
-    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.Name = 'Comment'
+    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The comment to add to the condition.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -1888,16 +1888,16 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'The identifier for the event to comment.'
-    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.Name = 'EventId'
+    extobj.DataType = ua.NodeId.from_string("i=15")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The identifier for the event to comment.'
     value.append(extobj)
     extobj = ua.Argument()
-    extobj.Description.Text = b'The comment to add to the condition.'
-    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.Name = 'Comment'
+    extobj.DataType = ua.NodeId.from_string("i=21")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'The comment to add to the condition.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -2622,10 +2622,10 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'If not 0, this parameter specifies a fixed time for which the Alarm is to be shelved.'
-    extobj.DataType = ua.NodeId.from_string("i=290")
     extobj.Name = 'ShelvingTime'
+    extobj.DataType = ua.NodeId.from_string("i=290")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'If not 0, this parameter specifies a fixed time for which the Alarm is to be shelved.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1
@@ -3488,10 +3488,10 @@ def create_standard_address_space_Part9(server):
     attrs.DataType = ua.NodeId.from_string("i=296")
     value = []
     extobj = ua.Argument()
-    extobj.Description.Text = b'If not 0, this parameter specifies a fixed time for which the Alarm is to be shelved.'
-    extobj.DataType = ua.NodeId.from_string("i=290")
     extobj.Name = 'ShelvingTime'
+    extobj.DataType = ua.NodeId.from_string("i=290")
     extobj.ValueRank = -1
+    extobj.Description.Text = b'If not 0, this parameter specifies a fixed time for which the Alarm is to be shelved.'
     value.append(extobj)
     attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)
     attrs.ValueRank = 1

--- a/schemas/generate_address_space.py
+++ b/schemas/generate_address_space.py
@@ -145,6 +145,9 @@ def create_standard_address_space_{0!s}(server):
                 self.make_ext_obj_code(indent, obj.value)
                 self.writecode(indent, 'value = extobj')
                 self.writecode(indent, 'attrs.Value = ua.Variant(value, ua.VariantType.ExtensionObject)')
+            elif obj.valuetype == "ListOfLocalizedText":
+                value = ['ua.LocalizedText({0})'.format(self.to_value(text)) for text in obj.value]
+                self.writecode(indent, 'attrs.Value = [{}]'.format(','.join(value)))
             else:
                 if obj.valuetype.startswith("ListOf"):
                     obj.valuetype = obj.valuetype[6:]

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -7,7 +7,6 @@ from opcua import ua
 from tests_subscriptions import SubscriptionTests
 from tests_common import CommonTests, add_server_methods
 from tests_xml import XmlTests
-from asyncio.executor import TimeoutError
 
 port_num1 = 48510
 

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -106,6 +106,6 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             The client only 'sees' an TimeoutError
         '''
         nenumstrings = self.opc.get_node(ua.ObjectIds.AxisScaleEnumeration_EnumStrings)
-        with self.assertNotRaises(TimeoutError):
+        with self.assertNotRaises(Exception):
             value = ua.Variant(nenumstrings.get_value())
 

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -6,7 +6,8 @@ from opcua import ua
 
 from tests_subscriptions import SubscriptionTests
 from tests_common import CommonTests, add_server_methods
-from tests_xml import XmlTests 
+from tests_xml import XmlTests
+from asyncio.executor import TimeoutError
 
 port_num1 = 48510
 
@@ -99,3 +100,13 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             self.assertEqual(state[0], 1)
         # test if client disconnected
         self.assertEqual(state[0], 2)
+
+    def test_enumstrings_getvalue(self):
+        ''' The real exception is server side, but is detected by using a client.
+            Alldue the server trace is also visible on the console.
+            The client only 'sees' an TimeoutError
+        '''
+        nenumstrings = self.opc.get_node(ua.ObjectIds.AxisScaleEnumeration_EnumStrings)
+        with self.assertNotRaises(TimeoutError):
+            value = ua.Variant(nenumstrings.get_value())
+


### PR DESCRIPTION
Fixed as crash for list of localized strings (see #426).

Old implemenation generated something like:
```python
attrs.Value = ua.Variant(['Server', 'Client', 'ClientAndServer', 'DiscoveryServer'], ua.VariantType.LocalizedText)
```
Due a change in the Variant implemention this cause an exception on to_binary. New implementation generates:

```python
attrs.Value = [ua.LocalizedText("Server"),ua.LocalizedText("Client"),ua.LocalizedText("ClientAndServer"),ua.LocalizedText("DiscoveryServer")]
```