### PR TITLE
Only add HistoryRead after event history is enabled

### DIFF
--- a/opcua/server/event_generator.py
+++ b/opcua/server/event_generator.py
@@ -62,7 +62,7 @@ class EventGenerator(object):
         self.event.SourceNode = source.nodeid
         self.event.SourceName = source.get_browse_name().Name
 
-        source.set_event_notifier([ua.EventNotifier.SubscribeToEvents, ua.EventNotifier.HistoryRead])
+        source.set_event_notifier([ua.EventNotifier.SubscribeToEvents])
         refs = []
         ref = ua.AddReferencesItem()
         ref.IsForward = True

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -217,7 +217,7 @@ class InternalServer(object):
             raise ua.UaError("Node does not generate events", event_notifier)
 
         if ua.EventNotifier.HistoryRead not in event_notifier:
-            event_notifier.append(ua.EventNotifier.HistoryRead)
+            event_notifier.add(ua.EventNotifier.HistoryRead)
             source.set_event_notifier(event_notifier)
 
         self.history_manager.historize_event(source, period, count)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -149,8 +149,16 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
 
     def test_historize_events(self):
         srv_node = self.srv.get_node(ua.ObjectIds.Server)
+        self.assertEqual(
+            srv_node.get_event_notifier(),
+            {ua.EventNotifier.SubscribeToEvents}
+        )
         srvevgen = self.srv.get_event_generator()
         self.srv.iserver.enable_history_event(srv_node, period=None)
+        self.assertEqual(
+            srv_node.get_event_notifier(),
+            {ua.EventNotifier.SubscribeToEvents, ua.EventNotifier.HistoryRead}
+        )
         srvevgen.trigger(message="Message")
         self.srv.iserver.disable_history_event(srv_node)
 
@@ -476,11 +484,7 @@ def check_eventgenerator_SourceServer(test, evgen):
     server = test.opc.get_server_node()
     test.assertEqual(evgen.event.SourceName, server.get_browse_name().Name)
     test.assertEqual(evgen.event.SourceNode, ua.NodeId(ua.ObjectIds.Server))
-
-    test.assertEqual(
-        server.get_event_notifier(),
-        {ua.EventNotifier.SubscribeToEvents, ua.EventNotifier.HistoryRead}
-    )
+    test.assertEqual(server.get_event_notifier(), {ua.EventNotifier.SubscribeToEvents})
 
     refs = server.get_referenced_nodes(ua.ObjectIds.GeneratesEvent, ua.BrowseDirection.Forward, ua.NodeClass.ObjectType, False)
     test.assertGreaterEqual(len(refs), 1)
@@ -489,11 +493,7 @@ def check_eventgenerator_SourceServer(test, evgen):
 def check_event_generator_object(test, evgen, obj):
     test.assertEqual(evgen.event.SourceName, obj.get_browse_name().Name)
     test.assertEqual(evgen.event.SourceNode, obj.nodeid)
-
-    test.assertEqual(
-        obj.get_event_notifier(),
-        {ua.EventNotifier.SubscribeToEvents, ua.EventNotifier.HistoryRead}
-    )
+    test.assertEqual(obj.get_event_notifier(), {ua.EventNotifier.SubscribeToEvents})
 
     refs = obj.get_referenced_nodes(ua.ObjectIds.GeneratesEvent, ua.BrowseDirection.Forward, ua.NodeClass.ObjectType, False)
     test.assertEqual(len(refs), 1)


### PR DESCRIPTION
I noticed in UaExpert that the attribute EventNotifier always gets the values SubscribeToEvents and HistoryRead.

Creating an event source with the call get_event_generator, the attribute EventNotifier is always set with SubscribeToEvents and HistoryRead. Probably HistoryRead must only be set after calling iserver.enable_history_event() to enable the history keeping for events. 
