### PR TITLE
Stop server on start failure and prevent exception

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -634,8 +634,9 @@ class AddressSpace(object):
 
     def delete_datachange_callback(self, handle):
         with self._lock:
-            nodeid, attr = self._handle_to_attribute_map.pop(handle)
-            self._nodes[nodeid].attributes[attr].datachange_callbacks.pop(handle)
+            if handle in self._handle_to_attribute_map:
+                nodeid, attr = self._handle_to_attribute_map.pop(handle)
+                self._nodes[nodeid].attributes[attr].datachange_callbacks.pop(handle)
 
     def add_method_callback(self, methodid, callback):
         with self._lock:

--- a/opcua/server/binary_server_asyncio.py
+++ b/opcua/server/binary_server_asyncio.py
@@ -109,5 +109,6 @@ class BinaryServer(object):
         self.logger.info("Closing asyncio socket server")
         for transport in self.iserver.asyncio_transports:
             transport.close()
-        self.loop.call_soon(self._server.close)
-        self.loop.run_coro_and_wait(self._server.wait_closed())
+        if self._server:
+            self.loop.call_soon(self._server.close)
+            self.loop.run_coro_and_wait(self._server.wait_closed())

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -276,7 +276,7 @@ class Server(object):
             self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
             self.bserver.set_policies(self._policies)
             self.bserver.start()
-        except Exception, exp:
+        except Exception as exp:
             self.iserver.stop()
             raise exp        
         

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -272,9 +272,14 @@ class Server(object):
         """
         self._setup_server_nodes()
         self.iserver.start()
-        self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
-        self.bserver.set_policies(self._policies)
-        self.bserver.start()
+        try:
+            self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
+            self.bserver.set_policies(self._policies)
+            self.bserver.start()
+        except Exception, exp:
+            self.iserver.stop()
+            raise exp        
+        
 
     def stop(self):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ sys.path.insert(0, ".")
 
 
 from tests_cmd_lines import TestCmdLines
-from tests_server import TestServer, TestServerCaching
+from tests_server import TestServer, TestServerCaching, TestServerStartError
 from tests_client import TestClient
 from tests_unit import TestUnit, TestMaskEnum
 from tests_history import TestHistory, TestHistorySQL, TestHistoryLimits, TestHistorySQLLimits

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -567,11 +567,11 @@ class TestServerStartError(unittest.TestCase):
     def test_port_in_use(self):
 
         server1 = Server()
-        server1.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num))
+        server1.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num + 1))
         server1.start()
 
         server2 = Server()
-        server2.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num))
+        server2.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num + 1))
         try:
             server2.start()
         except Exception:

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -561,3 +561,22 @@ class TestServerCaching(unittest.TestCase):
         self.assertEqual(server.get_node(id).get_value(), 123)
 
         os.remove(path)
+        
+class TestServerStartError(unittest.TestCase):
+    
+    def test_port_in_use(self):
+
+        server1 = Server()
+        server1.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num))
+        server1.start()
+
+        server2 = Server()
+        server2.set_endpoint('opc.tcp://localhost:{0:d}'.format(port_num))
+        try:
+            server2.start()
+        except Exception:
+            pass
+        
+        server1.stop()
+        server2.stop()
+


### PR DESCRIPTION
Created two fixes:

Starting the server failed when for eg a socket was already is use. The interval server was already started and caused the application to 'hang'. Fixed by stopping the internal server on an exception while starting the binary server. 

Noticed an exception on the server after an unsubscribe for data changes (by UaExpert)  on a node already deleted by the server. Added a check in delete_datachange_callback to prevent the KeyError exception.
