### PR TITLE
close socket even when timeout occurs

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -251,9 +251,11 @@ class Client(object):
         High level method
         Close session, secure channel and socket
         """
-        self.close_session()
-        self.close_secure_channel()
-        self.disconnect_socket()
+        try:
+            self.close_session()
+            self.close_secure_channel()
+        finally:
+            self.disconnect_socket()
 
     def connect_socket(self):
         """


### PR DESCRIPTION
When TimeoutError is thrown during the call to disconnect, the socket remains open. This will case the appliation to deadlock

This will address issue https://github.com/FreeOpcUa/python-opcua/issues/453
