### PR TITLE
Corrections for generating debian packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = ["python-dateutil", "pytz", "lxml"]
 if sys.version_info[0] < 3:
     install_requires.extend(["enum34", "trollius", "futures"])
 
-setup(name="freeopcua",
+setup(name="opcua",
       version="0.90.3",
       description="Pure Python OPC-UA client and server library",
       author="Olivier Roulet-Dubonnet",

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,3 +1,4 @@
 # Debian package generator configuration file
+# Build the debian package by running: python3 setup.py --command-packages=stdeb.command bdist_deb
 [DEFAULT]
 Depends: python-concurrent.futures, python-enum34, python-trollius


### PR DESCRIPTION
Hello

I changed the name option in setup.py to opcua (instead of freeopcua), so that the generated debian package filename will be python3-opcua.
Without this patch the package installation for python3-opcua-widgets fails (requesting python3-opcua to be installed).

Moreover, this is more in accordance with opcua-client and opcua-widgets packages naming.

Is this fine or must the package be called freeopcua?

Cedric
