### PR TITLE
Don't instantiate nodes without a modelling rule

### DIFF
--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -31,21 +31,14 @@ def instantiate(parent, node_type, nodeid=None, bname=None, dname=None, idx=0):
     elif isinstance(bname, str):
         bname = ua.QualifiedName.from_string(bname)
 
-    nodeids = _instantiate_node(parent.server, parent.nodeid, rdesc, nodeid, bname, dname=dname)
+    nodeids = _instantiate_node(parent.server, Node(parent.server, rdesc.NodeId), parent.nodeid, rdesc, nodeid, bname, dname=dname, toplevel=True)
     return [Node(parent.server, nid) for nid in nodeids]
 
 
-def _instantiate_node(server, parentid, rdesc, nodeid, bname, dname=None, recursive=True):
+def _instantiate_node(server, node_type, parentid, rdesc, nodeid, bname, dname=None, recursive=True, toplevel=False):
     """
     instantiate a node type under parent
     """
-    node_type = Node(server, rdesc.NodeId)
-    refs = node_type.get_referenced_nodes(refs=ua.ObjectIds.HasModellingRule)
-
-    # skip optional elements
-    if len(refs) == 1 and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
-        return []
-
     addnode = ua.AddNodesItem()
     addnode.RequestedNewNodeId = nodeid
     addnode.BrowseName = bname
@@ -84,14 +77,18 @@ def _instantiate_node(server, parentid, rdesc, nodeid, bname, dname=None, recurs
             for c_rdesc in descs:
                 # skip items that already exists, prefer the 'lowest' one in object hierarchy
                 if not ua_utils.is_child_present(node, c_rdesc.BrowseName):
+                    c_node_type = Node(server, c_rdesc.NodeId)
+                    # skip optional elements, or node without ModellingRule at top-level
+                    refs = c_node_type.get_referenced_nodes(refs=ua.ObjectIds.HasModellingRule)
+                    if (toplevel and len(refs) == 0) or (len(refs) == 1 and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional)):
+                        continue
+
                     # if root node being instantiated has a String NodeId, create the children with a String NodeId
                     if res.AddedNodeId.NodeIdType is ua.NodeIdType.String:
                         inst_nodeid = res.AddedNodeId.Identifier + "." + c_rdesc.BrowseName.Name
-                        nodeids = _instantiate_node(server, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(identifier=inst_nodeid, namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
+                        nodeids = _instantiate_node(server, c_node_type, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(identifier=inst_nodeid, namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
                     else:
-                        nodeids = _instantiate_node(server, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
+                        nodeids = _instantiate_node(server, c_node_type, res.AddedNodeId, c_rdesc, nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex), bname=c_rdesc.BrowseName)
                     added_nodes.extend(nodeids)
 
     return added_nodes
-
-

--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -77,10 +77,15 @@ def _instantiate_node(server, node_type, parentid, rdesc, nodeid, bname, dname=N
             for c_rdesc in descs:
                 # skip items that already exists, prefer the 'lowest' one in object hierarchy
                 if not ua_utils.is_child_present(node, c_rdesc.BrowseName):
+
                     c_node_type = Node(server, c_rdesc.NodeId)
-                    # skip optional elements, or node without ModellingRule at top-level
                     refs = c_node_type.get_referenced_nodes(refs=ua.ObjectIds.HasModellingRule)
-                    if (toplevel and len(refs) == 0) or (len(refs) == 1 and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional)):
+                    # exclude nodes without ModellingRule at top-level
+                    if toplevel and len(refs) == 0:
+                        continue
+                    # skip optional elements (server policy)
+                    if len(refs) == 1 and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                        logger.info("Will not instantiate optional node %s as part of %s", c_rdesc.BrowseName, addnode.BrowseName)
                         continue
 
                     # if root node being instantiated has a String NodeId, create the children with a String NodeId

--- a/opcua/common/node.py
+++ b/opcua/common/node.py
@@ -617,14 +617,20 @@ class Node(object):
         results =  self.server.add_references(params)
         _check_results(results, len(params))
 
-    def add_folder(self, nodeid, bname):
-        return  opcua.common.manage_nodes.create_folder(self, nodeid, bname)
+    def _add_modelling_rule(self, parent, mandatory):
+        if mandatory is not None and parent.get_node_class() == ua.NodeClass.ObjectType:
+            rule=ua.ObjectIds.ModellingRule_Mandatory if mandatory else ua.ObjectIds.ModellingRule_Optional
+            self.add_reference(rule, ua.ObjectIds.HasModellingRule, True, False)
+        return self
 
-    def add_object(self, nodeid, bname, objecttype=None):
-        return opcua.common.manage_nodes.create_object(self, nodeid, bname, objecttype)
+    def add_folder(self, nodeid, bname, mandatory=True):
+        return  opcua.common.manage_nodes.create_folder(self, nodeid, bname)._add_modelling_rule(self, mandatory)
 
-    def add_variable(self, nodeid, bname, val, varianttype=None, datatype=None):
-        return opcua.common.manage_nodes.create_variable(self, nodeid, bname, val, varianttype, datatype)
+    def add_object(self, nodeid, bname, objecttype=None, mandatory=True):
+        return opcua.common.manage_nodes.create_object(self, nodeid, bname, objecttype)._add_modelling_rule(self, mandatory)
+
+    def add_variable(self, nodeid, bname, val, varianttype=None, datatype=None, mandatory=True):
+        return opcua.common.manage_nodes.create_variable(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self, mandatory)
 
     def add_object_type(self, nodeid, bname):
         return opcua.common.manage_nodes.create_object_type(self, nodeid, bname)
@@ -635,11 +641,12 @@ class Node(object):
     def add_data_type(self, nodeid, bname, description=None):
         return opcua.common.manage_nodes.create_data_type(self, nodeid, bname, description=None)
 
-    def add_property(self, nodeid, bname, val, varianttype=None, datatype=None):
-        return opcua.common.manage_nodes.create_property(self, nodeid, bname, val, varianttype, datatype)
+    def add_property(self, nodeid, bname, val, varianttype=None, datatype=None, mandatory=True):
+        return opcua.common.manage_nodes.create_property(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self, mandatory)
 
-    def add_method(self, *args):
-        return opcua.common.manage_nodes.create_method(self, *args)
+    def add_method(self, *args, **kwargs):
+        mandatory = kwargs.pop('mandatory', True)
+        return opcua.common.manage_nodes.create_method(self, *args, **kwargs)._add_modelling_rule(self, mandatory)
 
     def add_reference_type(self, nodeid, bname, symmetric=True, inversename=None):
         return opcua.common.manage_nodes.create_reference_type(self, nodeid, bname, symmetric, inversename)

--- a/opcua/common/node.py
+++ b/opcua/common/node.py
@@ -570,6 +570,15 @@ class Node(object):
         results = opcua.common.manage_nodes.delete_nodes(self.server, [self], recursive, delete_references)
         _check_results(results)
 
+    def _fill_delete_reference_item(self, rdesc, bidirectional = False):
+        ditem = ua.DeleteReferencesItem()
+        ditem.SourceNodeId = self.nodeid
+        ditem.TargetNodeId = rdesc.NodeId
+        ditem.ReferenceTypeId = rdesc.ReferenceTypeId
+        ditem.IsForward = rdesc.IsForward
+        ditem.DeleteBidirectional = bidirectional
+        return ditem
+
     def delete_reference(self, target, reftype, forward=True, bidirectional=True):
         """
         Delete given node's references from address space
@@ -584,13 +593,7 @@ class Node(object):
         else:
             raise ua.UaStatusCodeError(ua.StatusCodes.BadNotFound)
 
-        ditem = ua.DeleteReferencesItem()
-        ditem.SourceNodeId = self.nodeid
-        ditem.TargetNodeId = rdesc.NodeId
-        ditem.ReferenceTypeId = rdesc.ReferenceTypeId
-        ditem.IsForward = rdesc.IsForward
-        ditem.DeleteBidirectional = bidirectional
-
+        ditem = self._fill_delete_reference_item(rdesc, bidirectional)
         self.server.delete_references([ditem])[0].check()
 
     def add_reference(self, target, reftype, forward=True, bidirectional=True):
@@ -617,20 +620,33 @@ class Node(object):
         results =  self.server.add_references(params)
         _check_results(results, len(params))
 
-    def _add_modelling_rule(self, parent, mandatory):
+    def _add_modelling_rule(self, parent, mandatory=True):
         if mandatory is not None and parent.get_node_class() == ua.NodeClass.ObjectType:
             rule=ua.ObjectIds.ModellingRule_Mandatory if mandatory else ua.ObjectIds.ModellingRule_Optional
             self.add_reference(rule, ua.ObjectIds.HasModellingRule, True, False)
         return self
 
-    def add_folder(self, nodeid, bname, mandatory=True):
-        return  opcua.common.manage_nodes.create_folder(self, nodeid, bname)._add_modelling_rule(self, mandatory)
+    def set_modelling_rule(self, mandatory):
+        parent = self.get_parent()
+        if parent is None:
+            return ua.StatusCode(ua.StatusCodes.BadParentNodeIdInvalid)
+        if parent.get_node_class() != ua.NodeClass.ObjectType:
+            return ua.StatusCode(ua.StatusCodes.BadTypeMismatch)
+        # remove all existing modelling rule
+        rules = self.get_references(ua.ObjectIds.HasModellingRule)
+        self.server.delete_references(list(map(self._fill_delete_reference_item, rules)))
 
-    def add_object(self, nodeid, bname, objecttype=None, mandatory=True):
-        return opcua.common.manage_nodes.create_object(self, nodeid, bname, objecttype)._add_modelling_rule(self, mandatory)
+        self._add_modelling_rule(parent, mandatory)
+        return ua.StatusCode()
 
-    def add_variable(self, nodeid, bname, val, varianttype=None, datatype=None, mandatory=True):
-        return opcua.common.manage_nodes.create_variable(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self, mandatory)
+    def add_folder(self, nodeid, bname):
+        return  opcua.common.manage_nodes.create_folder(self, nodeid, bname)._add_modelling_rule(self)
+
+    def add_object(self, nodeid, bname, objecttype=None):
+        return opcua.common.manage_nodes.create_object(self, nodeid, bname, objecttype)._add_modelling_rule(self)
+
+    def add_variable(self, nodeid, bname, val, varianttype=None, datatype=None):
+        return opcua.common.manage_nodes.create_variable(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self)
 
     def add_object_type(self, nodeid, bname):
         return opcua.common.manage_nodes.create_object_type(self, nodeid, bname)
@@ -641,12 +657,11 @@ class Node(object):
     def add_data_type(self, nodeid, bname, description=None):
         return opcua.common.manage_nodes.create_data_type(self, nodeid, bname, description=None)
 
-    def add_property(self, nodeid, bname, val, varianttype=None, datatype=None, mandatory=True):
-        return opcua.common.manage_nodes.create_property(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self, mandatory)
+    def add_property(self, nodeid, bname, val, varianttype=None, datatype=None):
+        return opcua.common.manage_nodes.create_property(self, nodeid, bname, val, varianttype, datatype)._add_modelling_rule(self)
 
-    def add_method(self, *args, **kwargs):
-        mandatory = kwargs.pop('mandatory', True)
-        return opcua.common.manage_nodes.create_method(self, *args, **kwargs)._add_modelling_rule(self, mandatory)
+    def add_method(self, *args):
+        return opcua.common.manage_nodes.create_method(self, *args)._add_modelling_rule(self)
 
     def add_reference_type(self, nodeid, bname, symmetric=True, inversename=None):
         return opcua.common.manage_nodes.create_reference_type(self, nodeid, bname, symmetric, inversename)

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -653,6 +653,8 @@ class CommonTests(object):
         v_t = dev_t.add_variable(0, "sensor", 1.0)
         p_t = dev_t.add_property(0, "sensor_id", "0340")
         ctrl_t = dev_t.add_object(0, "controller")
+        v_opt_t = dev_t.add_variable(0, "vendor", 1.0, mandatory=False)
+        v_none_t = dev_t.add_variable(0, "model", 1.0, mandatory=None)
         prop_t = ctrl_t.add_property(0, "state", "Running")
 
         # Create device sutype
@@ -668,6 +670,11 @@ class CommonTests(object):
         self.assertEqual(mydevice.get_type_definition(), dev_t.nodeid)
         obj = mydevice.get_child(["0:controller"])
         prop = mydevice.get_child(["0:controller", "0:state"])
+        with self.assertRaises(ua.UaError):
+            mydevice.get_child(["0:controller", "0:vendor"])
+        with self.assertRaises(ua.UaError):
+            mydevice.get_child(["0:controller", "0:model"])
+
         self.assertEqual(prop.get_type_definition().Identifier, ua.ObjectIds.PropertyType)
         self.assertEqual(prop.get_value(), "Running")
         self.assertNotEqual(prop.nodeid, prop_t.nodeid)

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -43,23 +43,27 @@ def add_server_methods(srv):
     base_otype= srv.get_node(ua.ObjectIds.BaseObjectType)
     custom_otype = base_otype.add_object_type(2, 'ObjectWithMethodsType')
     custom_otype.add_method(2, 'ServerMethodDefault', func4)
-    custom_otype.add_method(2, 'ServerMethodMandatory', func4, mandatory=True)
-    custom_otype.add_method(2, 'ServerMethodOptional', func4, mandatory=False)
-    custom_otype.add_method(2, 'ServerMethodNone', func4, mandatory=None)
+    custom_otype.add_method(2, 'ServerMethodMandatory', func4).set_modelling_rule(True)
+    custom_otype.add_method(2, 'ServerMethodOptional', func4).set_modelling_rule(False)
+    custom_otype.add_method(2, 'ServerMethodNone', func4).set_modelling_rule(None)
     o.add_object(2, 'ObjectWithMethods', custom_otype)
 
 
 def _test_modelling_rules(test, parent, mandatory, result):
-    f = parent.add_folder(3, 'MyFolder', mandatory=mandatory)
+    f = parent.add_folder(3, 'MyFolder')
+    f.set_modelling_rule(mandatory)
     test.assertEqual(f.get_referenced_nodes(ua.ObjectIds.HasModellingRule), result)
 
-    o = parent.add_object(3, 'MyObject', mandatory=mandatory)
+    o = parent.add_object(3, 'MyObject')
+    o.set_modelling_rule(mandatory)
     test.assertEqual(o.get_referenced_nodes(ua.ObjectIds.HasModellingRule), result)
 
-    v = parent.add_variable(3, 'MyVariable', 6, mandatory=mandatory)
+    v = parent.add_variable(3, 'MyVariable', 6)
+    v.set_modelling_rule(mandatory)
     test.assertEqual(v.get_referenced_nodes(ua.ObjectIds.HasModellingRule), result)
 
-    p = parent.add_property(3, 'MyProperty', 10, mandatory=mandatory)
+    p = parent.add_property(3, 'MyProperty', 10)
+    p.set_modelling_rule(mandatory)
     test.assertEqual(p.get_referenced_nodes(ua.ObjectIds.HasModellingRule), result)
 
 
@@ -723,7 +727,7 @@ class CommonTests(object):
         self.assertEqual([of, op], path)
         target = self.opc.get_node("i=13387")
         path = target.get_path()
-        self.assertEqual([self.opc.nodes.root, self.opc.nodes.types, self.opc.nodes.object_types, self.opc.nodes.base_object_type, self.opc.nodes.folder_type, self.opc.get_node(ua.ObjectIds.FileDirectoryType), target], path)  
+        self.assertEqual([self.opc.nodes.root, self.opc.nodes.types, self.opc.nodes.object_types, self.opc.nodes.base_object_type, self.opc.nodes.folder_type, self.opc.get_node(ua.ObjectIds.FileDirectoryType), target], path)
 
     def test_get_endpoints(self):
         endpoints = self.opc.get_endpoints()
@@ -740,7 +744,7 @@ class CommonTests(object):
         devd_t = dev_t.add_object_type(0, "MyDeviceDervived")
         v_t = devd_t.add_variable(0, "childparam", 1.0)
         p_t = devd_t.add_property(0, "sensorx_id", "0340")
-        
+
 
         nodes = copy_node(self.opc.nodes.objects, dev_t)
         mydevice = nodes[0]
@@ -759,15 +763,17 @@ class CommonTests(object):
         v_t = dev_t.add_variable(0, "sensor", 1.0)
         p_t = dev_t.add_property(0, "sensor_id", "0340")
         ctrl_t = dev_t.add_object(0, "controller")
-        v_opt_t = dev_t.add_variable(0, "vendor", 1.0, mandatory=False)
-        v_none_t = dev_t.add_variable(0, "model", 1.0, mandatory=None)
+        v_opt_t = dev_t.add_variable(0, "vendor", 1.0)
+        v_opt_t.set_modelling_rule(False)
+        v_none_t = dev_t.add_variable(0, "model", 1.0)
+        v_none_t.set_modelling_rule(None)
         prop_t = ctrl_t.add_property(0, "state", "Running")
 
         # Create device sutype
         devd_t = dev_t.add_object_type(0, "MyDeviceDervived")
         v_t = devd_t.add_variable(0, "childparam", 1.0)
         p_t = devd_t.add_property(0, "sensorx_id", "0340")
-        
+
         # instanciate device
         nodes = instantiate(self.opc.nodes.objects, dev_t, bname="2:Device0001")
         mydevice = nodes[0]
@@ -784,10 +790,10 @@ class CommonTests(object):
         self.assertEqual(prop.get_type_definition().Identifier, ua.ObjectIds.PropertyType)
         self.assertEqual(prop.get_value(), "Running")
         self.assertNotEqual(prop.nodeid, prop_t.nodeid)
-        
+
         # instanciate device subtype
         nodes = instantiate(self.opc.nodes.objects, devd_t, bname="2:Device0002")
-        mydevicederived = nodes[0] 
+        mydevicederived = nodes[0]
         prop1 = mydevicederived.get_child(["0:sensorx_id"])
         var1 = mydevicederived.get_child(["0:childparam"])
         var_parent = mydevicederived.get_child(["0:sensor"])
@@ -828,7 +834,7 @@ class CommonTests(object):
         # create enum type
         enums = self.opc.get_root_node().get_child(["0:Types", "0:DataTypes", "0:BaseDataType", "0:Enumeration"])
         myenum_type = enums.add_data_type(0, "MyEnum")
-        es = myenum_type.add_variable(0, "EnumStrings", [ua.LocalizedText("String0"), ua.LocalizedText("String1"), ua.LocalizedText("String2")], ua.VariantType.LocalizedText) 
+        es = myenum_type.add_variable(0, "EnumStrings", [ua.LocalizedText("String0"), ua.LocalizedText("String1"), ua.LocalizedText("String2")], ua.VariantType.LocalizedText)
         #es.set_value_rank(1)
         # instantiate
         o = self.opc.get_objects_node()
@@ -886,4 +892,3 @@ class CommonTests(object):
             }
         for dt, vdt in test_data.items():
             self.assertEqual(ua_utils.data_type_to_variant_type(self.opc.get_node(ua.NodeId(dt))), vdt)
-


### PR DESCRIPTION
From the OPC-UA specification Part 3 (6.2.2)
> If no ModellingRule exists then the Node is neither considered for instantiation of a type nor for
subtyping.

This PR implements this behavior.
Tool-generated nodesets should already contain the appoproriate modelling rules.

I have patched the `Node` API to add them for types' children as well (with opt-out).