### PR TITLE
allow passing specific method results

### DIFF
--- a/opcua/common/methods.py
+++ b/opcua/common/methods.py
@@ -60,12 +60,17 @@ def uamethod(func):
             parent = args[0]
             args = args[1:]
             result = func(self, parent, *[arg.Value for arg in args])
-        if isinstance(result, ua.CallMethodResult):
+        if result is None:
+            return []
+        elif isinstance(result, ua.CallMethodResult):
             result.OutputArguments = to_variant(*result.OutputArguments)
             return result
         elif isinstance(result, ua.StatusCode):
             return result
-        return to_variant(result)
+        elif isinstance(result, tuple):
+            return to_variant(*result)
+        else:
+            return to_variant(result)
     return wrapper
 
 

--- a/opcua/common/methods.py
+++ b/opcua/common/methods.py
@@ -60,7 +60,11 @@ def uamethod(func):
             parent = args[0]
             args = args[1:]
             result = func(self, parent, *[arg.Value for arg in args])
-
+        if isinstance(result, ua.CallMethodResult):
+            result.OutputArguments = to_variant(*result.OutputArguments)
+            return result
+        elif isinstance(result, ua.StatusCode):
+            return result
         return to_variant(result)
     return wrapper
 
@@ -70,5 +74,3 @@ def to_variant(*args):
     for arg in args:
         uaargs.append(ua.Variant(arg))
     return uaargs
-
-

--- a/opcua/common/methods.py
+++ b/opcua/common/methods.py
@@ -12,28 +12,34 @@ def call_method(parent, methodid, *args):
     nodeid of method as a NodeId object
     arguments are variants or python object convertible to variants.
     which may be of different types
-    returns a list of variants which are output of the method
+    returns a list of values or a single value depending on the output of the method
+    """
+    result = call_method_full(parent, methodid, *args)
+
+    if len(result.OutputArguments) == 0:
+        return None
+    elif len(result.OutputArguments) == 1:
+        return result.OutputArguments[0]
+    else:
+        return result.OutputArguments
+
+
+def call_method_full(parent, methodid, *args):
+    """
+    Call an OPC-UA method. methodid is browse name of child method or the
+    nodeid of method as a NodeId object
+    arguments are variants or python object convertible to variants.
+    which may be of different types
+    returns a CallMethodResult object with converted OutputArguments
     """
     if isinstance(methodid, (str, ua.uatypes.QualifiedName)):
         methodid = parent.get_child(methodid).nodeid
     elif isinstance(methodid, node.Node):
         methodid = methodid.nodeid
 
-    arguments = []
-    for arg in args:
-        if not isinstance(arg, ua.Variant):
-            arg = ua.Variant(arg)
-        arguments.append(arg)
-
-    result = _call_method(parent.server, parent.nodeid, methodid, arguments)
-
-    if len(result.OutputArguments) == 0:
-        return None
-    elif len(result.OutputArguments) == 1:
-        return result.OutputArguments[0].Value
-    else:
-        return [var.Value for var in result.OutputArguments]
-
+    result = _call_method(parent.server, parent.nodeid, methodid, to_variant(*args))
+    result.OutputArguments = [var.Value for var in result.OutputArguments]
+    return result
 
 def _call_method(server, parentnodeid, methodid, arguments):
     request = ua.CallMethodRequest()

--- a/opcua/common/methods.py
+++ b/opcua/common/methods.py
@@ -72,5 +72,7 @@ def uamethod(func):
 def to_variant(*args):
     uaargs = []
     for arg in args:
-        uaargs.append(ua.Variant(arg))
+        if not isinstance(arg, ua.Variant):
+            arg = ua.Variant(arg)
+        uaargs.append(arg)
     return uaargs

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -445,8 +445,14 @@ class MethodService(object):
                 res.StatusCode = ua.StatusCode(ua.StatusCodes.BadNothingToDo)
             else:
                 try:
-                    res.OutputArguments = node.call(method.ObjectId, *method.InputArguments)
-                    for _ in method.InputArguments:
+                    result = node.call(method.ObjectId, *method.InputArguments)
+                    if isinstance(result, ua.CallMethodResult):
+                        res = result
+                    elif isinstance(result, ua.StatusCode):
+                        res.StatusCode = result
+                    else:
+                        res.OutputArguments = result
+                    while len(res.InputArgumentResults) < len(method.InputArguments):
                         res.InputArgumentResults.append(ua.StatusCode())
                 except Exception:
                     self.logger.exception("Error executing method call %s, an exception was raised: ", method)


### PR DESCRIPTION
This PR patches the method call system to handle `ua.StatusCode` and `ua.CallMethodResult` properly.
So the callback can indicate errors or invalid arguments.
