### PR TITLE
Added properties to configure MaxMessageSize and MaxChunkCount

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -114,6 +114,9 @@ class Client(object):
         self._session_counter = 1
         self.keepalive = None
         self.nodes = Shortcuts(self.uaclient)
+        self._maxMessageSize = 0 # No limits
+        self._maxChunkCount = 0 # No limits
+
 
     def __enter__(self):
         self.connect()
@@ -147,6 +150,20 @@ class Client(object):
         initial password from the URL will be overwritten
         """
         self._password = pwd
+
+    def set_max_messagesize(self, maxMessageSize):
+        """
+        Set the max messagesize for the connection.
+        """
+        self._maxMessageSize = maxMessageSize
+    
+
+    def set_max_chunkcount(self, maxChunkCount):
+        """
+        Set the max chunkcount for the connection.
+        """
+        self._maxChunkCount = maxChunkCount
+    
 
     def set_security_string(self, string):
         """
@@ -270,7 +287,7 @@ class Client(object):
         """
         Send OPC-UA hello to server
         """
-        ack = self.uaclient.send_hello(self.server_url.geturl())
+        ack = self.uaclient.send_hello(self.server_url.geturl(), self._maxMessageSize, self._maxChunkCount)
         # FIXME check ack
 
     def open_secure_channel(self, renew=False):

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -114,8 +114,8 @@ class Client(object):
         self._session_counter = 1
         self.keepalive = None
         self.nodes = Shortcuts(self.uaclient)
-        self._maxMessageSize = 0 # No limits
-        self._maxChunkCount = 0 # No limits
+        self.max_messagesize = 0 # No limits
+        self.max_chunkcount = 0 # No limits
 
 
     def __enter__(self):
@@ -149,21 +149,7 @@ class Client(object):
         Set user password for the connection.
         initial password from the URL will be overwritten
         """
-        self._password = pwd
-
-    def set_max_messagesize(self, maxMessageSize):
-        """
-        Set the max messagesize for the connection.
-        """
-        self._maxMessageSize = maxMessageSize
-    
-
-    def set_max_chunkcount(self, maxChunkCount):
-        """
-        Set the max chunkcount for the connection.
-        """
-        self._maxChunkCount = maxChunkCount
-    
+        self._password = pwd   
 
     def set_security_string(self, string):
         """
@@ -287,7 +273,7 @@ class Client(object):
         """
         Send OPC-UA hello to server
         """
-        ack = self.uaclient.send_hello(self.server_url.geturl(), self._maxMessageSize, self._maxChunkCount)
+        ack = self.uaclient.send_hello(self.server_url.geturl(), self.max_messagesize, self.max_chunkcount)
         # FIXME check ack
 
     def open_secure_channel(self, renew=False):

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -144,11 +144,11 @@ class UASocketClient(object):
         self._socket.socket.shutdown(socket.SHUT_RDWR)
         self._socket.socket.close()
 
-    def send_hello(self, url, maxMessageSize = 0, maxChunkCount = 0):
+    def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
         hello = ua.Hello()
         hello.EndpointUrl = url
-        hello.MaxMessageSize = maxMessageSize
-        hello.MaxChunkCount = maxChunkCount
+        hello.MaxMessageSize = max_messagesize
+        hello.MaxChunkCount = max_chunkcount
         future = Future()
         with self._lock:
             self._callbackmap[0] = future
@@ -220,8 +220,8 @@ class UaClient(object):
     def disconnect_socket(self):
         return self._uasocket.disconnect_socket()
 
-    def send_hello(self, url, maxMessageSize, maxMessageCount):
-        return self._uasocket.send_hello(url, maxMessageSize, maxMessageCount)
+    def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
+        return self._uasocket.send_hello(url, max_messagesize, max_chunkcount)
 
     def open_secure_channel(self, params):
         return self._uasocket.open_secure_channel(params)

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -144,9 +144,11 @@ class UASocketClient(object):
         self._socket.socket.shutdown(socket.SHUT_RDWR)
         self._socket.socket.close()
 
-    def send_hello(self, url):
+    def send_hello(self, url, maxMessageSize = 0, maxChunkCount = 0):
         hello = ua.Hello()
         hello.EndpointUrl = url
+        hello.MaxMessageSize = maxMessageSize
+        hello.MaxChunkCount = maxChunkCount
         future = Future()
         with self._lock:
             self._callbackmap[0] = future
@@ -218,8 +220,8 @@ class UaClient(object):
     def disconnect_socket(self):
         return self._uasocket.disconnect_socket()
 
-    def send_hello(self, url):
-        return self._uasocket.send_hello(url)
+    def send_hello(self, url, maxMessageSize, maxMessageCount):
+        return self._uasocket.send_hello(url, maxMessageSize, maxMessageCount)
 
     def open_secure_channel(self, params):
         return self._uasocket.open_secure_channel(params)

--- a/opcua/ua/uaprotocol_hand.py
+++ b/opcua/ua/uaprotocol_hand.py
@@ -17,8 +17,8 @@ class Hello(uatypes.FrozenClass):
         self.ProtocolVersion = 0
         self.ReceiveBufferSize = 65536
         self.SendBufferSize = 65536
-        self.MaxMessageSize = 0
-        self.MaxChunkCount = 0
+        self.MaxMessageSize = 0 # No limits
+        self.MaxChunkCount = 0 # No limits
         self.EndpointUrl = ""
         self._freeze = True
 


### PR DESCRIPTION
Solves the issue #492. Now it is possible to set MaxMessageSize and MaxChunkCount via properties. Servers that don't accept 0 can be connected now when the new properties are used with proper values before establishing a connection to a server  (in my case I used `client.set_max_messagesize(65536)`). 

**Important:** Currently only `client.send_hello` makes usage of the new introduced properties. It needs to be checked if other operations also should make usage of this (properties) for consistency reasons.