### PR TITLE
Replace leftover prints with logging

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -21,7 +21,7 @@ use_crypto = True
 try:
     from opcua.crypto import uacrypto
 except ImportError:
-    print("cryptography is not installed, use of crypto disabled")
+    logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
     use_crypto = False
 
 

--- a/opcua/common/structures.py
+++ b/opcua/common/structures.py
@@ -7,6 +7,7 @@ for custom structures
 import os
 import importlib
 import re
+import logging
 # The next two imports are for generated code
 from datetime import datetime
 import uuid
@@ -229,7 +230,7 @@ def load_type_definitions(server, nodes=None):
             if ref_desc_list:  #some server put extra things here
                 name = _clean_name(ndesc.BrowseName.Name)
                 if not name in structs_dict:
-                    print("Error {} is found as child of binary definition node but is not found in xml".format(name))
+                    logging.getLogger(__name__).warning("Error {} is found as child of binary definition node but is not found in xml".format(name))
                     continue
                 nodeid = ref_desc_list[0].NodeId
                 ua.register_extension_object(name, nodeid, structs_dict[name])

--- a/opcua/server/binary_server_asyncio.py
+++ b/opcua/server/binary_server_asyncio.py
@@ -113,7 +113,7 @@ class BinaryServer(object):
             sockname = self._server.sockets[0].getsockname()
             self.hostname = sockname[0]
             self.port = sockname[1]
-        print('Listening on {0}:{1}'.format(self.hostname, self.port))
+        self.logger.warning('Listening on {0}:{1}'.format(self.hostname, self.port))
 
     def stop(self):
         self.logger.info("Closing asyncio socket server")

--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -84,6 +84,7 @@ class HistoryDict(HistoryStorageInterface):
         self._datachanges_period = {}
         self._events = {}
         self._events_periods = {}
+        self.logger = logging.getLogger(__name__)
 
     def new_historized_node(self, node_id, period, count=0):
         if node_id in self._datachanges:
@@ -105,7 +106,7 @@ class HistoryDict(HistoryStorageInterface):
     def read_node_history(self, node_id, start, end, nb_values):
         cont = None
         if node_id not in self._datachanges:
-            print("Error attempt to read history for a node which is not historized")
+            self.logger.warning("Error attempt to read history for a node which is not historized")
             return [], cont
         else:
             if start is None:

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -29,7 +29,7 @@ use_crypto = True
 try:
     from opcua.crypto import uacrypto
 except ImportError:
-    print("cryptography is not installed, use of crypto disabled")
+    logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
     use_crypto = False
 
 

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -468,6 +468,6 @@ class UaProcessor(object):
         to be called when client has disconnected to ensure we really close
         everything we should
         """
-        print("Cleanup client connection: ", self.name)
+        self.logger.info("Cleanup client connection: ", self.name)
         if self.session:
             self.session.close_session(True)


### PR DESCRIPTION
In various places in the library, there were some print()s. These make it hard to control the output of the library externally, e.g. when supressing logging output for clean testing-logs.

This commit attempts to replace all leftover print()s by logging calls.