### PR TITLE
Expand namespace migration in XMLImporter

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -263,7 +263,7 @@ class XmlImporter(object):
                             obj2 = ua.NodeId(getattr(ua.ObjectIds, v2))
                         else:
                             obj2 = ua.NodeId.from_string(v2)
-                        setattr(obj, attname, obj2)
+                        setattr(obj, attname, self._migrate_ns(obj2))
                         break
             elif not hasattr(obj2, "ua_types"):
                 # we probably have a list

--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -43,7 +43,7 @@ class XmlImporter(object):
         """
         aliases_mapped = {}
         for alias, node_id in aliases.items():
-            aliases_mapped[alias] = self._migrate_ns(self.to_nodeid(node_id))
+            aliases_mapped[alias] = self.to_nodeid(node_id)
         return aliases_mapped
 
     def import_xml(self, xmlpath):
@@ -151,7 +151,7 @@ class XmlImporter(object):
             node.TypeDefinition = self._migrate_ns(obj.typedef)
         return node
 
-    def to_nodeid(self, nodeid):
+    def _to_nodeid(self, nodeid):
         if isinstance(nodeid, ua.NodeId):
             return nodeid
         elif not nodeid:
@@ -165,6 +165,9 @@ class XmlImporter(object):
                 return self.aliases[nodeid]
             else:
                 return ua.NodeId(getattr(ua.ObjectIds, nodeid))
+
+    def to_nodeid(self, nodeid):
+        return self._migrate_ns(self._to_nodeid(nodeid))
 
     def add_object(self, obj):
         node = self._get_node(obj)
@@ -398,7 +401,7 @@ class XmlImporter(object):
             ref.ReferenceTypeId = self.to_nodeid(data.reftype)
             ref.SourceNodeId = self._migrate_ns(obj.nodeid)
             ref.TargetNodeClass = ua.NodeClass.DataType
-            ref.TargetNodeId = self._migrate_ns(self.to_nodeid(data.target))
+            ref.TargetNodeId = self.to_nodeid(data.target)
             refs.append(ref)
         self._add_references(refs)
 


### PR DESCRIPTION
The first commit fixes an issue with extension objects, as the datatype nodeid was not migrated.
The second commit enforces namespace migration in all XMLImporter.to_nodeid uses.
