### PR TITLE
Fix handling of CharArray in Structs

### DIFF
--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -22,6 +22,7 @@ from opcua.client.client import Client
 from opcua.crypto import security_policies
 from opcua.common.event_objects import BaseEvent
 from opcua.common.shortcuts import Shortcuts
+from opcua.common.structures import load_type_definitions
 from opcua.common.xmlexporter import XmlExporter
 from opcua.common.xmlimporter import XmlImporter
 from opcua.common.ua_utils import get_nodes_of_namespace
@@ -278,8 +279,8 @@ class Server(object):
             self.bserver.start()
         except Exception as exp:
             self.iserver.stop()
-            raise exp        
-        
+            raise exp
+
 
     def stop(self):
         """
@@ -436,13 +437,13 @@ class Server(object):
 
     def export_xml_by_ns(self, path, namespaces=None):
         """
-        Export nodes of one or more namespaces to an XML file.  
+        Export nodes of one or more namespaces to an XML file.
         Namespaces used by nodes are always exported for consistency.
         Args:
             server: opc ua server to use
             path: name of the xml file to write
             namespaces: list of string uris or int indexes of the namespace to export, if not provide all ns are used except 0
-    
+
         Returns:
         """
         if namespaces is None:
@@ -522,3 +523,6 @@ class Server(object):
         Returns:
         """
         self.iserver.isession.add_method_callback(node.nodeid, callback)
+
+    def load_type_definitions(self, nodes=None):
+        return load_type_definitions(self, nodes)

--- a/opcua/ua/ua_binary.py
+++ b/opcua/ua/ua_binary.py
@@ -269,6 +269,8 @@ def to_binary(uatype, val):
     elif isinstance(uatype, (str, unicode)) and hasattr(ua.VariantType, uatype):
         vtype = getattr(ua.VariantType, uatype)
         return pack_uatype(vtype, val)
+    elif isinstance(uatype, (str, unicode)) and hasattr(Primitives, uatype):
+        return getattr(Primitives, uatype).pack(val)
     elif isinstance(val, (IntEnum, Enum)):
         return Primitives.UInt32.pack(val.value)
     elif isinstance(val, ua.NodeId):
@@ -475,6 +477,8 @@ def from_binary(uatype, data):
     elif isinstance(uatype, (str, unicode)) and hasattr(ua.VariantType, uatype):
         vtype = getattr(ua.VariantType, uatype)
         return unpack_uatype(vtype, data)
+    elif isinstance(uatype, (str, unicode)) and hasattr(Primitives, uatype):
+        return  getattr(Primitives, uatype).unpack(data)
     else:
         return struct_from_binary(uatype, data)
 


### PR DESCRIPTION
If methods are used with custom data types, which contain strings, UAExpert encodes these as `CharArray`.

However, the current struct handling packs/unpacks only Variant types, which cover only a subset of the standard types for binary encoding.
This PR considers the Primitives types as well; Variant types take precedence.

In addition the server now exposes `load_type_definitions` (same as for the client) that can be called to setup extention object class automatically at server-side.

Without this fix the `CharArray` is handled as a structure and the methods call will never get a response due to an exception in between.

