### PR TITLE
Reap Client-KeepAlive Threads for reconnect

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -374,6 +374,11 @@ class Client(object):
         ep = Client.find_endpoint(response.ServerEndpoints, self.security_policy.Mode, self.security_policy.URI)
         self._policy_ids = ep.UserIdentityTokens
         self.session_timeout = response.RevisedSessionTimeout
+        # In case there was an existing session, try to reap existing KeepAlive-Thread
+        try:
+            self.keepalive.stop()
+        except AttributeError:
+            pass
         self.keepalive = KeepAlive(self, min(self.session_timeout, self.secure_channel_timeout) * 0.7)  # 0.7 is from spec
         self.keepalive.start()
         return response


### PR DESCRIPTION
> In some situations, Clients seem to create multiple KeepAlive-Threads.
> The old ones are never properly stopped, and there are no references to
> them to be able to stop them. This causes programs not to quit properly
> or completely.
> 
> To Redeem, we now check for an existing KeepAlive-Thread whenever
> creating a new one — and try to stop the existing one beforehand.

We discovered this when running some combinations of clients in our test-bed. The tests would not terminate because some KeepAlive-Threads were leftover …