### PR TITLE
fix typo: “sesssion”

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ All protocol code is under opcua directory
 
 ## Running tests:
 
-python tests.py
+```
+./run-tests.sh
+```
 
 ## Coverage
 

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -48,7 +48,7 @@ class Server(object):
     All methods are threadsafe
 
     If you need more flexibility you call directly the Ua Service methods
-    on the iserver  or iserver.isesssion object members.
+    on the iserver  or iserver.isession object members.
 
     During startup the standard address space will be constructed, which may be
     time-consuming when running a server on a less powerful device (e.g. a

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -138,7 +138,7 @@ class UaProcessor(object):
 
             response.Parameters.ServerSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
-            self.logger.info("sending create sesssion response")
+            self.logger.info("sending create session response")
             self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
 
         elif typeid == ua.NodeId(ua.ObjectIds.CloseSessionRequest_Encoding_DefaultBinary):
@@ -148,7 +148,7 @@ class UaProcessor(object):
             self.session.close_session(deletesubs)
 
             response = ua.CloseSessionResponse()
-            self.logger.info("sending close sesssion response")
+            self.logger.info("sending close session response")
             self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
 
         elif typeid == ua.NodeId(ua.ObjectIds.ActivateSessionRequest_Encoding_DefaultBinary):


### PR DESCRIPTION
Very minor change to fix three mis-spellings of "session", twice in log statements and once in a docstring.

Just to be paranoid, I wanted to run tests after these changes, and found that the Readme instructions for runnings tests are outdated. Hence, I changed those too.