### PR TITLE
During call to connect, disconnect socket when create_session fails

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -207,8 +207,8 @@ class Client(object):
         """
         Connect, ask server for endpoints, and disconnect
         """
+        self.connect_socket()
         try:
-            self.connect_socket()
             self.send_hello()
             self.open_secure_channel()
             endpoints = self.get_endpoints()
@@ -221,8 +221,8 @@ class Client(object):
         """
         Connect, ask server for a list of known servers, and disconnect
         """
+        self.connect_socket()
         try:
-            self.connect_socket()
             self.send_hello()
             self.open_secure_channel()  # spec says it should not be necessary to open channel
             servers = self.find_servers()
@@ -235,8 +235,8 @@ class Client(object):
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
+        self.connect_socket()
         try:
-            self.connect_socket()
             self.send_hello()
             self.open_secure_channel()
             servers = self.find_servers_on_network()
@@ -251,9 +251,9 @@ class Client(object):
         Connect, create and activate session
         """
         self.connect_socket()
-        self.send_hello()
-        self.open_secure_channel()
         try:
+            self.send_hello()
+            self.open_secure_channel()
             self.create_session()
         except _base.TimeoutError as e:
             self.disconnect_socket() # clean up open socket

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -207,36 +207,42 @@ class Client(object):
         """
         Connect, ask server for endpoints, and disconnect
         """
-        self.connect_socket()
-        self.send_hello()
-        self.open_secure_channel()
-        endpoints = self.get_endpoints()
-        self.close_secure_channel()
-        self.disconnect_socket()
+        try:
+            self.connect_socket()
+            self.send_hello()
+            self.open_secure_channel()
+            endpoints = self.get_endpoints()
+            self.close_secure_channel()
+        finally:
+            self.disconnect_socket()
         return endpoints
 
     def connect_and_find_servers(self):
         """
         Connect, ask server for a list of known servers, and disconnect
         """
-        self.connect_socket()
-        self.send_hello()
-        self.open_secure_channel()  # spec says it should not be necessary to open channel
-        servers = self.find_servers()
-        self.close_secure_channel()
-        self.disconnect_socket()
+        try:
+            self.connect_socket()
+            self.send_hello()
+            self.open_secure_channel()  # spec says it should not be necessary to open channel
+            servers = self.find_servers()
+            self.close_secure_channel()
+        finally:
+            self.disconnect_socket()
         return servers
 
     def connect_and_find_servers_on_network(self):
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
-        self.connect_socket()
-        self.send_hello()
-        self.open_secure_channel()
-        servers = self.find_servers_on_network()
-        self.close_secure_channel()
-        self.disconnect_socket()
+        try:
+            self.connect_socket()
+            self.send_hello()
+            self.open_secure_channel()
+            servers = self.find_servers_on_network()
+            self.close_secure_channel()
+        finally:
+            self.disconnect_socket()
         return servers
 
     def connect(self):

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -246,7 +246,11 @@ class Client(object):
         self.connect_socket()
         self.send_hello()
         self.open_secure_channel()
-        self.create_session()
+        try:
+            self.create_session()
+        except _base.TimeoutError as e:
+            self.disconnect_socket() # clean up open socket
+            raise e
         self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
 
     def disconnect(self):

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -6,7 +6,6 @@ try:
 except ImportError:  # support for python2
     from urlparse import urlparse
 
-from concurrent.futures import _base
 from opcua import ua
 from opcua.client.ua_client import UaClient
 from opcua.common.xmlimporter import XmlImporter
@@ -255,9 +254,9 @@ class Client(object):
             self.send_hello()
             self.open_secure_channel()
             self.create_session()
-        except _base.TimeoutError as e:
+        except:
             self.disconnect_socket() # clean up open socket
-            raise e
+            raise
         self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
 
     def disconnect(self):

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -6,6 +6,7 @@ try:
 except ImportError:  # support for python2
     from urlparse import urlparse
 
+from concurrent.futures import _base
 from opcua import ua
 from opcua.client.ua_client import UaClient
 from opcua.common.xmlimporter import XmlImporter


### PR DESCRIPTION
Under certain conditions, normally when the server is under heavy load, it may fail creating session, if this happens we need to close the socket.