### PR TITLE
Fix password authentication using SecurityPolicy#None

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -458,7 +458,7 @@ class Client(object):
             # and EncryptionAlgorithm is null
             if self._password:
                 self.logger.warning("Sending plain-text password")
-                params.UserIdentityToken.Password = password
+                params.UserIdentityToken.Password = password.encode('utf8')
             params.UserIdentityToken.EncryptionAlgorithm = None
         elif self._password:
             data, uri = self._encrypt_password(password, policy_uri)


### PR DESCRIPTION
Password needs to be encoded as utf-8, otherwise binary serialization
will fail with:

~/venv/lib/python3.6/site-packages/opcua/client/client.py in connect(self)
    258             self.disconnect_socket() # clean up open socket
    259             raise
--> 260         self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
    261
    262     def disconnect(self):

~/venv/lib/python3.6/site-packages/opcua/client/client.py in activate_session(self, username, password, certificate)
    432         else:
    433             self._add_user_auth(params, username, password)
--> 434         return self.uaclient.activate_session(params)
    435
    436     def _add_anonymous_auth(self, params):

~/venv/lib/python3.6/site-packages/opcua/client/ua_client.py in activate_session(self, parameters)
    249         request = ua.ActivateSessionRequest()
    250         request.Parameters = parameters
--> 251         data = self._uasocket.send_request(request)
    252         response = struct_from_binary(ua.ActivateSessionResponse, data)
    253         self.logger.debug(response)

~/venv/lib/python3.6/site-packages/opcua/client/ua_client.py in send_request(self, request, callback, timeout, message_type)
     73         returns response object if no callback is provided
     74         """
---> 75         future = self._send_request(request, callback, timeout, message_type)
     76         if not callback:
     77             data = future.result(self.timeout)

~/venv/lib/python3.6/site-packages/opcua/client/ua_client.py in _send_request(self, request, callback, timeout, message_type)
     52             self.logger.debug("Sending: %s", request)
     53             try:
---> 54                 binreq = struct_to_binary(request)
     55             except:
     56                 # reset reqeust handle if any error

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in struct_to_binary(obj)
    256                 pass
    257             else:
--> 258                 packet.append(to_binary(uatype, val))
    259     return b''.join(packet)
    260

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in to_binary(uatype, val)
    279         return variant_to_binary(val)
    280     elif hasattr(val, "ua_types"):
--> 281         return struct_to_binary(val)
    282     else:
    283         raise UaError("No known way to pack {} of type {} to ua binary".format(val, uatype))

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in struct_to_binary(obj)
    256                 pass
    257             else:
--> 258                 packet.append(to_binary(uatype, val))
    259     return b''.join(packet)
    260

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in to_binary(uatype, val)
    269     elif isinstance(uatype, (str, unicode)) and hasattr(ua.VariantType, uatype):
    270         vtype = getattr(ua.VariantType, uatype)
--> 271         return pack_uatype(vtype, val)
    272     elif isinstance(uatype, (str, unicode)) and hasattr(Primitives, uatype):
    273         return getattr(Primitives, uatype).pack(val)

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in pack_uatype(vtype, value)
    183         return Primitives.Bytes.pack(value)
    184     elif vtype == ua.VariantType.ExtensionObject:
--> 185         return extensionobject_to_binary(value)
    186     elif vtype in (ua.VariantType.NodeId, ua.VariantType.ExpandedNodeId):
    187         return nodeid_to_binary(value)

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in extensionobject_to_binary(obj)
    455         TypeId = ua.extension_object_ids[obj.__class__.__name__]
    456         Encoding = 0x01
--> 457         Body = struct_to_binary(obj)
    458     packet = []
    459     packet.append(nodeid_to_binary(TypeId))

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in struct_to_binary(obj)
    256                 pass
    257             else:
--> 258                 packet.append(to_binary(uatype, val))
    259     return b''.join(packet)
    260

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in to_binary(uatype, val)
    269     elif isinstance(uatype, (str, unicode)) and hasattr(ua.VariantType, uatype):
    270         vtype = getattr(ua.VariantType, uatype)
--> 271         return pack_uatype(vtype, val)
    272     elif isinstance(uatype, (str, unicode)) and hasattr(Primitives, uatype):
    273         return getattr(Primitives, uatype).pack(val)

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in pack_uatype(vtype, value)
    179 def pack_uatype(vtype, value):
    180     if hasattr(Primitives, vtype.name):
--> 181         return getattr(Primitives, vtype.name).pack(value)
    182     elif vtype.value > 25:
    183         return Primitives.Bytes.pack(value)

~/venv/lib/python3.6/site-packages/opcua/ua/ua_binary.py in pack(data)
     52             return Primitives.Int32.pack(-1)
     53         length = len(data)
---> 54         return Primitives.Int32.pack(length) + data
     55
     56     @staticmethod

TypeError: can't concat str to bytes