### PR TITLE
Respect monitored item trigger (DataChangeFilter)

### DIFF
--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -177,6 +177,17 @@ class Subscription(object):
         """
         return self._subscribe(nodes, attr, queuesize=0)
 
+    def subscribe_data_timestamp_change(self, nodes, attr=ua.AttributeIds.Value):
+        """
+        Subscribe for data and timestamp change events for a node or list of nodes.
+        default attribute is Value.
+        Return a handle which can be used to unsubscribe
+        If more control is necessary use create_monitored_items method
+        """
+        timestamp_filter = ua.DataChangeFilter()
+        timestamp_filter.Trigger = ua.DataChangeTrigger(2) # send notification when status, value or timestamp change
+        return self._subscribe(nodes, attr, mfilter=timestamp_filter, queuesize=0)
+
     def subscribe_events(self, sourcenode=ua.ObjectIds.Server, evtypes=ua.ObjectIds.BaseEventType, evfilter=None, queuesize=0):
         """
         Subscribe to events from a node. Default node is Server node.

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -640,9 +640,7 @@ class AddressSpace(object):
             attval = node.attributes[attr]
             old = attval.value
             attval.value = value
-            cbs = []
-            if old.Value != value.Value:  # only send call callback when a value change has happend
-                cbs = list(attval.datachange_callbacks.items())
+            cbs = list(attval.datachange_callbacks.items())
 
         for k, v in cbs:
             try:

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -640,7 +640,9 @@ class AddressSpace(object):
             attval = node.attributes[attr]
             old = attval.value
             attval.value = value
-            cbs = list(attval.datachange_callbacks.items())
+            cbs = []
+            if old.SourceTimestamp != value.SourceTimestamp or old.ServerTimestamp != value.ServerTimestamp:
+                cbs = list(attval.datachange_callbacks.items())
 
         for k, v in cbs:
             try:

--- a/opcua/tools.py
+++ b/opcua/tools.py
@@ -357,11 +357,11 @@ def uasubscribe():
                         "--eventtype",
                         dest="eventtype",
                         default="datachange",
-                        choices=['datachange', 'event'],
+                        choices=['datachange', 'timeordatachange', 'event'],
                         help="Event type to subscribe to")
 
     args = parse_args(parser, requirenodeid=False)
-    if args.eventtype == "datachange":
+    if args.eventtype == "datachange" or args.eventtype == "timeordatachange":
         _require_nodeid(parser, args)
     else:
         # FIXME: this is broken, someone may have written i=84 on purpose
@@ -377,6 +377,8 @@ def uasubscribe():
         sub = client.create_subscription(500, handler)
         if args.eventtype == "datachange":
             sub.subscribe_data_change(node)
+        elif args.eventtype == "timeordatachange":
+            sub.subscribe_data_timestamp_change(node)
         else:
             sub.subscribe_events(node)
         print("Type Ctr-C to exit")

--- a/tests/tests_subscriptions.py
+++ b/tests/tests_subscriptions.py
@@ -157,6 +157,48 @@ class SubscriptionTests(object):
         self.assertEqual(myhandler.datachange_count, 4)
         sub.delete()
 
+    def test_subscription_count_timestamp_trigger(self):
+        myhandler = MySubHandlerCounter()
+        sub = self.opc.create_subscription(1, myhandler)
+        o = self.opc.get_objects_node()
+        var = o.add_variable(3, 'SubVarCounter', 0.1)
+        sub.subscribe_data_timestamp_change(var)
+        nb = 12
+        for i in range(nb):
+            val = var.get_value()
+            var.set_value(val +1)
+        time.sleep(0.2)  # let last event arrive
+        self.assertEqual(myhandler.datachange_count, nb + 1)
+        sub.delete()
+
+    def test_subscription_count_timestamp_trigger_no_change(self):
+        myhandler = MySubHandlerCounter()
+        sub = self.opc.create_subscription(1, myhandler)
+        o = self.opc.get_objects_node()
+        var = o.add_variable(3, 'SubVarCounter', 0.1)
+        sub.subscribe_data_timestamp_change(var)
+        nb = 12
+        for i in range(nb):
+            val = var.get_value()
+            var.set_value(val)
+        time.sleep(0.2)  # let last event arrive
+        self.assertEqual(myhandler.datachange_count, nb + 1)
+        sub.delete()
+
+    def test_subscription_count_timestamp_trigger_same_timestamp(self):
+        myhandler = MySubHandlerCounter()
+        sub = self.opc.create_subscription(1, myhandler)
+        o = self.opc.get_objects_node()
+        var = o.add_variable(3, 'SubVarCounter', 0.1)
+        sub.subscribe_data_timestamp_change(var)
+        nb = 12
+        for i in range(nb):
+            val = var.get_data_value() # use exactly the same value including timestamps
+            var.set_value(val)
+        time.sleep(0.2)  # let last event arrive
+        self.assertEqual(myhandler.datachange_count, 1)
+        sub.delete()
+
     def test_subscription_overload_simple(self):
         nb = 10
         myhandler = MySubHandler()
@@ -502,7 +544,7 @@ class SubscriptionTests(object):
         propertystring2 = "This is my test 2"
         evgen2.event.PropertyNum = propertynum2
         evgen2.event.PropertyString = propertystring2
-        
+
         for i in range(3):
             evgen1.trigger()
             evgen2.trigger()
@@ -560,7 +602,7 @@ class SubscriptionTests(object):
         propertystring3 = "This is my test 3"
         evgen3.event.PropertyNum3 = propertynum3
         evgen3.event.PropertyString = propertystring2
-        
+
         for i in range(3):
             evgen1.trigger()
             evgen2.trigger()


### PR DESCRIPTION
As already mentioned in #332 according to https://forum.unified-automation.com/post282.html the `DataChangeFilter` allows clients to get subscription updates even if the value does not change. I need this kind of functionality because of legacy components, so I can't switch to e.g. Events. 

To achieve this I removed the filter for identical values and only avoid calling the callbacks of a value if the timestamps are exactly the same.  The actual filtering based on the `DataChangeFilter` is done similar to the `deadband` filter. I added a new subscription method which enables clients, tools and tests to subscribe with a `DataChangeFilter` of `StatusValueTimestamp`.

Please let me know if you have any doubts.