### PR TITLE
Allow importing XML from string

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -538,12 +538,12 @@ class Client(object):
     def delete_nodes(self, nodes, recursive=False):
         return delete_nodes(self.uaclient, nodes, recursive)
 
-    def import_xml(self, path):
+    def import_xml(self, path=None, xmlstring=None):
         """
         Import nodes defined in xml
         """
         importer = XmlImporter(self)
-        return importer.import_xml(path)
+        return importer.import_xml(path, xmlstring)
 
     def export_xml(self, nodes, path):
         """

--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -46,12 +46,12 @@ class XmlImporter(object):
             aliases_mapped[alias] = self.to_nodeid(node_id)
         return aliases_mapped
 
-    def import_xml(self, xmlpath):
+    def import_xml(self, xmlpath=None, xmlstring=None):
         """
         import xml and return added nodes
         """
         self.logger.info("Importing XML file %s", xmlpath)
-        self.parser = xmlparser.XMLParser(xmlpath)
+        self.parser = xmlparser.XMLParser(xmlpath, xmlstring)
 
         self.namespaces = self._map_namespaces(self.parser.get_used_namespaces())
         self.aliases = self._map_aliases(self.parser.get_aliases())

--- a/opcua/common/xmlparser.py
+++ b/opcua/common/xmlparser.py
@@ -89,13 +89,16 @@ class ExtObj(object):
 
 class XMLParser(object):
 
-    def __init__(self, xmlpath):
+    def __init__(self, xmlpath=None, xmlstring=None):
         self.logger = logging.getLogger(__name__)
         self._retag = re.compile(r"(\{.*\})(.*)")
         self.path = xmlpath
 
-        self.tree = ET.parse(xmlpath)
-        self.root = self.tree.getroot()
+        if xmlstring:
+            self.root = ET.fromstring(xmlstring)
+        else:
+            self.root = ET.parse(xmlpath).getroot()
+
         # FIXME: hard to get these xml namespaces with ElementTree, we may have to shift to lxml
         self.ns = {
             'base': "http://opcfoundation.org/UA/2011/03/UANodeSet.xsd",

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -425,12 +425,12 @@ class Server(object):
 
         return custom_t
 
-    def import_xml(self, path):
+    def import_xml(self, path=None, xmlstring=None):
         """
         Import nodes defined in xml
         """
         importer = XmlImporter(self)
-        return importer.import_xml(path)
+        return importer.import_xml(path, xmlstring)
 
     def export_xml(self, nodes, path):
         """

--- a/tests/tests_xml.py
+++ b/tests/tests_xml.py
@@ -349,11 +349,7 @@ class XmlTests(object):
         </UANodeSet>
         """
 
-        fp = open('tmp_test_import-nillable.xml', 'w')
-        fp.write(xml)
-        fp.close()
-        # TODO: when the xml parser also support loading from string, remove write to file
-        _new_nodes = self.opc.import_xml('tmp_test_import-nillable.xml')
+        _new_nodes = self.opc.import_xml(xmlstring=xml)
         var_string = self.opc.get_node(ua.NodeId('test_xml.string.nillabel', 2))
         var_bool = self.opc.get_node(ua.NodeId('test_xml.bool.nillabel', 2))
         self.assertEqual(var_string.get_value(), None)


### PR DESCRIPTION
Introduce an optional parameter xmlstring throughout the import_xml
chain (client, server, xmlimporter, xmlparser) to allow specifying
a XML string instead of a path.

If both are given the string takes precendence.