### PR TITLE
Convert client threads to daemon

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -38,6 +38,7 @@ class KeepAlive(Thread):
             in milliseconds.
         """
         Thread.__init__(self)
+        self.daemon = True
         self.logger = logging.getLogger(__name__)
 
         self.client = client

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -39,6 +39,7 @@ class UASocketClient(object):
         should not be necessary to call directly
         """
         self._thread = Thread(target=self._run)
+        self._thread.daemon = True
         self._thread.start()
 
     def _send_request(self, request, callback=None, timeout=1000, message_type=ua.MessageType.SecureMessage):


### PR DESCRIPTION
Currently, when you create a client in a Python shell and you forget to disconnect from the server before exiting your shell, the shell will hang indefinitely and you either need to use Ctrl + C (only works for some shells) or exit out of the terminal window completely. 

This appears to be because the client threads don't stop when the shell receives the exit command. To resolve this, I converted the two client threads into daemon threads so that they are stopped when the shell is exited.

Before this fix, the lines below would cause the shell to hang. Converting to daemon threads resolves this.

```
from opcua import Client
client = Client("opc.tcp://localhost:4840/freeopcua/server/")
client.connect()
quit()
```