### PR TITLE
join() background threads in client after stopping them

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -481,8 +481,9 @@ class Client(object):
         """
         Close session
         """
-        if self.keepalive:
+        if self.keepalive and self.keepalive.is_alive():
             self.keepalive.stop()
+            self.keepalive.join()
         return self.uaclient.close_session(True)
 
     def get_root_node(self):

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -139,12 +139,14 @@ class UASocketClient(object):
         self.start()
 
     def disconnect_socket(self):
-        self.logger.info("stop request")
+        self.logger.info("Request to close socket received")
         self._do_stop = True
         self._socket.socket.shutdown(socket.SHUT_RDWR)
         self._socket.socket.close()
+        self.logger.info("Socket closed, waiting for receiver thread to terminate...")
         if self._thread and self._thread.is_alive():
             self._thread.join()
+        self.logger.info("Done closing socket: Receiving thread terminated, socket disconnected")
 
     def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
         hello = ua.Hello()

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -143,6 +143,8 @@ class UASocketClient(object):
         self._do_stop = True
         self._socket.socket.shutdown(socket.SHUT_RDWR)
         self._socket.socket.close()
+        if self._thread and self._thread.is_alive():
+            self._thread.join()
 
     def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
         hello = ua.Hello()

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -3,6 +3,8 @@ import unittest
 from opcua import Client
 from opcua import Server
 from opcua import ua
+from opcua.client.ua_client import UASocketClient
+from opcua.common.utils import SocketWrapper
 
 from tests_subscriptions import SubscriptionTests
 from tests_common import CommonTests, add_server_methods
@@ -105,7 +107,19 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             Alldue the server trace is also visible on the console.
             The client only 'sees' an TimeoutError
         '''
-        nenumstrings = self.opc.get_node(ua.ObjectIds.AxisScaleEnumeration_EnumStrings)
+        nenumstrings = self.clt.get_node(ua.ObjectIds.AxisScaleEnumeration_EnumStrings)
         with self.assertNotRaises(Exception):
             value = ua.Variant(nenumstrings.get_value())
+            
+    def test_uasocketclient_connect_disconnect(self):
+        """Initialize, connect, and disconnect a UaSocketClient
+        """
+        uaclt = UASocketClient()
+        uaclt.connect_socket('127.0.0.1', port_num1)
+        self.assertTrue(uaclt._thread.is_alive())
+        self.assertIsInstance(uaclt._socket, SocketWrapper)
+        
+        # disconnect_socket() should shut down the receiving thread
+        uaclt.disconnect_socket()
+        self.assertFalse(uaclt._thread.is_alive())
 


### PR DESCRIPTION
Fixes #599 

In addition to the example shown there, I noticed that the same applies to the keepalive thread in `opcua.client.Client` where I added a `join()` too.