### PR TITLE
PEP-8 fixes for opcua/client/*.py files

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -296,7 +296,8 @@ class Client(object):
             params.RequestType = ua.SecurityTokenRequestType.Renew
         params.SecurityMode = self.security_policy.Mode
         params.RequestedLifetime = self.secure_channel_timeout
-        nonce = utils.create_nonce(self.security_policy.symmetric_key_size)   # length should be equal to the length of key of symmetric encryption
+        # length should be equal to the length of key of symmetric encryption
+        nonce = utils.create_nonce(self.security_policy.symmetric_key_size)
         params.ClientNonce = nonce  # this nonce is used to create a symmetric key
         result = self.uaclient.open_secure_channel(params)
         self.security_policy.make_symmetric_key(nonce, result.ServerNonce)
@@ -360,7 +361,8 @@ class Client(object):
         desc.ApplicationType = ua.ApplicationType.Client
 
         params = ua.CreateSessionParameters()
-        nonce = utils.create_nonce(32)  # at least 32 random bytes for server to prove possession of private key (specs part 4, 5.6.2.2)
+        # at least 32 random bytes for server to prove possession of private key (specs part 4, 5.6.2.2)
+        nonce = utils.create_nonce(32)
         params.ClientNonce = nonce
         params.ClientCertificate = self.security_policy.client_certificate
         params.ClientDescription = desc
@@ -383,7 +385,8 @@ class Client(object):
         ep = Client.find_endpoint(response.ServerEndpoints, self.security_policy.Mode, self.security_policy.URI)
         self._policy_ids = ep.UserIdentityTokens
         self.session_timeout = response.RevisedSessionTimeout
-        self.keepalive = KeepAlive(self, min(self.session_timeout, self.secure_channel_timeout) * 0.7)  # 0.7 is from spec
+        self.keepalive = KeepAlive(
+            self, min(self.session_timeout, self.secure_channel_timeout) * 0.7)  # 0.7 is from spec
         self.keepalive.start()
         return response
 

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -47,7 +47,7 @@ class KeepAlive(Thread):
 
         # some server support no timeout, but we do not trust them
         if self.timeout == 0:
-            self.timeout = 3600000 # 1 hour
+            self.timeout = 3600000  # 1 hour
 
     def run(self):
         self.logger.debug("starting keepalive thread with period of %s milliseconds", self.timeout)
@@ -95,7 +95,7 @@ class Client(object):
         """
         self.logger = logging.getLogger(__name__)
         self.server_url = urlparse(url)
-        #take initial username and password from the url
+        # take initial username and password from the url
         self._username = self.server_url.username
         self._password = self.server_url.password
         self.name = "Pure Python Client"
@@ -104,8 +104,8 @@ class Client(object):
         self.product_uri = "urn:freeopcua.github.no:client"
         self.security_policy = ua.SecurityPolicy()
         self.secure_channel_id = None
-        self.secure_channel_timeout = 3600000 # 1 hour
-        self.session_timeout = 3600000 # 1 hour
+        self.secure_channel_timeout = 3600000  # 1 hour
+        self.session_timeout = 3600000  # 1 hour
         self._policy_ids = []
         self.uaclient = UaClient(timeout)
         self.user_certificate = None
@@ -114,9 +114,8 @@ class Client(object):
         self._session_counter = 1
         self.keepalive = None
         self.nodes = Shortcuts(self.uaclient)
-        self.max_messagesize = 0 # No limits
-        self.max_chunkcount = 0 # No limits
-
+        self.max_messagesize = 0  # No limits
+        self.max_chunkcount = 0  # No limits
 
     def __enter__(self):
         self.connect()
@@ -149,7 +148,7 @@ class Client(object):
         Set user password for the connection.
         initial password from the URL will be overwritten
         """
-        self._password = pwd   
+        self._password = pwd
 
     def set_security_string(self, string):
         """
@@ -254,8 +253,8 @@ class Client(object):
             self.send_hello()
             self.open_secure_channel()
             self.create_session()
-        except:
-            self.disconnect_socket() # clean up open socket
+        except Exception:
+            self.disconnect_socket()  # clean up open socket
             raise
         self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
 
@@ -298,7 +297,7 @@ class Client(object):
         params.SecurityMode = self.security_policy.Mode
         params.RequestedLifetime = self.secure_channel_timeout
         nonce = utils.create_nonce(self.security_policy.symmetric_key_size)   # length should be equal to the length of key of symmetric encryption
-        params.ClientNonce = nonce	# this nonce is used to create a symmetric key
+        params.ClientNonce = nonce  # this nonce is used to create a symmetric key
         result = self.uaclient.open_secure_channel(params)
         self.security_policy.make_symmetric_key(nonce, result.ServerNonce)
         self.secure_channel_timeout = result.SecurityToken.RevisedLifetime
@@ -568,5 +567,3 @@ class Client(object):
 
     def load_type_definitions(self, nodes=None):
         return load_type_definitions(self, nodes)
-
-

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -137,7 +137,8 @@ class UASocketClient(object):
         """
         self.logger.info("opening connection")
         sock = socket.create_connection((host, port))
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)  # nodelay ncessary to avoid packing in one frame, some servers do not like it
+        # nodelay ncessary to avoid packing in one frame, some servers do not like it
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self._socket = ua.utils.SocketWrapper(sock)
         self.start()
 

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -52,7 +52,7 @@ class UASocketClient(object):
             self.logger.debug("Sending: %s", request)
             try:
                 binreq = struct_to_binary(request)
-            except:
+            except Exception:
                 # reset reqeust handle if any error
                 # see self._create_request_header
                 self._request_handle -= 1
@@ -117,7 +117,10 @@ class UASocketClient(object):
         with self._lock:
             future = self._callbackmap.pop(request_id, None)
             if future is None:
-                raise ua.UaError("No future object found for request: {0}, callbacks in list are {1}".format(request_id, self._callbackmap.keys()))
+                raise ua.UaError(
+                    "No future object found for request: {0}, callbacks in list are {1}"
+                    .format(request_id, self._callbackmap.keys())
+                )
         future.set_result(body)
 
     def _create_request_header(self, timeout=1000):
@@ -144,7 +147,7 @@ class UASocketClient(object):
         self._socket.socket.shutdown(socket.SHUT_RDWR)
         self._socket.socket.close()
 
-    def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
+    def send_hello(self, url, max_messagesize=0, max_chunkcount=0):
         hello = ua.Hello()
         hello.EndpointUrl = url
         hello.MaxMessageSize = max_messagesize
@@ -162,7 +165,7 @@ class UASocketClient(object):
         request = ua.OpenSecureChannelRequest()
         request.Parameters = params
         future = self._send_request(request, message_type=ua.MessageType.SecureOpen)
-        
+
         # FIXME: we have a race condition here
         # we can get a packet with the new token id before we reach to store it..
         response = struct_from_binary(ua.OpenSecureChannelResponse, future.result(self.timeout))
@@ -172,9 +175,9 @@ class UASocketClient(object):
 
     def close_secure_channel(self):
         """
-        close secure channel. It seems to trigger a shutdown of socket
-        in most servers, so be prepare to reconnect.
-        OPC UA specs Part 6, 7.1.4 say that Server does not send a CloseSecureChannel response and should just close socket
+        close secure channel. It seems to trigger a shutdown of socket in most servers, so be prepare to reconnect.
+        OPC UA specs Part 6, 7.1.4 say that Server does not send a CloseSecureChannel response and should just close
+        socket
         """
         self.logger.info("close_secure_channel")
         request = ua.CloseSecureChannelRequest()
@@ -220,7 +223,7 @@ class UaClient(object):
     def disconnect_socket(self):
         return self._uasocket.disconnect_socket()
 
-    def send_hello(self, url, max_messagesize = 0, max_chunkcount = 0):
+    def send_hello(self, url, max_messagesize=0, max_chunkcount=0):
         return self._uasocket.send_hello(url, max_messagesize, max_chunkcount)
 
     def open_secure_channel(self, params):
@@ -431,10 +434,10 @@ class UaClient(object):
         # check if answer looks ok
         try:
             self._uasocket.check_answer(data, "while waiting for publish response")
-        except BadTimeout: # Spec Part 4, 7.28
+        except BadTimeout:  # Spec Part 4, 7.28
             self.publish()
             return
-        except BadNoSubscription: # Spec Part 5, 13.8.1
+        except BadNoSubscription:  # Spec Part 5, 13.8.1
             # BadNoSubscription is expected after deleting the last subscription.
             #
             # We should therefore also check for len(self._publishcallbacks) == 0, but
@@ -460,7 +463,7 @@ class UaClient(object):
             #       catch BadTimeout above. However, it's not really clear what this code
             #       does so it stays in, doesn't seem to hurt.
             self.logger.exception("Error parsing notificatipn from server")
-            self.publish([]) #send publish request ot server so he does stop sending notifications
+            self.publish([])  # send publish request ot server so he does stop sending notifications
             return
 
         # look for callback
@@ -525,7 +528,6 @@ class UaClient(object):
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
-
 
     def delete_nodes(self, params):
         self.logger.info("delete_nodes")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = opcua/ua/,opcua/common/event_objects.py,opcua/server/standard_address_space/standard_address_space*.py


### PR DESCRIPTION
The README says:

> Code follows PEP8 apart for line lengths which should be max 120 characters and OPC UA structures that keep camel case from XML definition.

But that's not actually true :)

This PR does two things:
* Address all but one of warnings and errors found by `flake8` in the `opcua/client` directory. Why only that directory? I had to start somewhere. Why "all but one"? Because the remaining one will be fixed once the accompanying `FIXME` comment is addressed.
* Add a `setup.cfg` file that captures the flags that make `flake8` behave the way the README file suggests we want a style checker to behave in this repo (ignore auto-generated files, line length of 120). You can now run the command `pip install flake8 && flake8 opcua` and get a list of PEP8 violations that are actually worth addressing.