### PR TITLE
Fix re-initialization of ThreadLoop in InternalServer

### DIFF
--- a/opcua/server/binary_server_asyncio.py
+++ b/opcua/server/binary_server_asyncio.py
@@ -91,13 +91,16 @@ class BinaryServer(object):
         self.hostname = hostname
         self.port = port
         self.iserver = internal_server
-        self.loop = internal_server.loop
+        self.loop = None
         self._server = None
         self._policies = []
         self.clients = []
 
     def set_policies(self, policies):
         self._policies = policies
+
+    def set_loop(self, loop):
+        self.loop = loop
 
     def start(self):
         prop = dict(
@@ -128,3 +131,4 @@ class BinaryServer(object):
         if self._server:
             self.loop.call_soon(self._server.close)
             self.loop.run_coro_and_wait(self._server.wait_closed())
+        self.loop = None

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -65,7 +65,7 @@ class InternalServer(object):
 
         self.load_standard_address_space(shelffile)
 
-        self.loop = utils.ThreadLoop()
+        self.loop = None
         self.asyncio_transports = []
         self.subscription_service = SubscriptionService(self.loop, self.aspace)
 
@@ -131,6 +131,7 @@ class InternalServer(object):
         self.logger.info("starting internal server")
         for edp in self.endpoints:
             self._known_servers[edp.Server.ApplicationUri] = ServerDesc(edp.Server)
+        self.loop = utils.ThreadLoop()
         self.loop.start()
         Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_State)).set_value(0, ua.VariantType.Int32)
         Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_StartTime)).set_value(datetime.utcnow())
@@ -141,6 +142,7 @@ class InternalServer(object):
         self.logger.info("stopping internal server")
         self.isession.close_session()
         self.loop.stop()
+        self.loop = None
         self.history_manager.stop()
 
     def _set_current_time(self):

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -360,8 +360,10 @@ class Server(object):
         self._setup_server_nodes()
         self.iserver.start()
         try:
-            self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
+            if not self.bserver:
+                self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
             self.bserver.set_policies(self._policies)
+            self.bserver.set_loop(self.iserver.loop)
             self.bserver.start()
         except Exception as exp:
             self.iserver.stop()


### PR DESCRIPTION
### This fixes #627


The various Server objects use a utils.ThreadLoop to handle the
asyncio-mainloop. This Thread(~like) object is not getting
re-initialized in a start()⇒stop()⇒start()-scenario, which leads to a
»Threads may only be started once« exception.
    
To fix this, we dump the old ThreadLoop object upon re-initialization,
and hand the new object around.

I’m happy for any feedback, both on whether this is the right way, and if i’ve analyzed the problem correctly.

Thanks!
