### PR TITLE
Fix re-initialization of ThreadLoop in InternalServer

### DIFF
--- a/opcua/server/binary_server_asyncio.py
+++ b/opcua/server/binary_server_asyncio.py
@@ -91,13 +91,16 @@ class BinaryServer(object):
         self.hostname = hostname
         self.port = port
         self.iserver = internal_server
-        self.loop = internal_server.loop
+        self.loop = None
         self._server = None
         self._policies = []
         self.clients = []
 
     def set_policies(self, policies):
         self._policies = policies
+
+    def set_loop(self, loop):
+        self.loop = loop
 
     def start(self):
         prop = dict(
@@ -128,3 +131,4 @@ class BinaryServer(object):
         if self._server:
             self.loop.call_soon(self._server.close)
             self.loop.run_coro_and_wait(self._server.wait_closed())
+        self.loop = None

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -360,8 +360,10 @@ class Server(object):
         self._setup_server_nodes()
         self.iserver.start()
         try:
-            self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
+            if not self.bserver:
+                self.bserver = BinaryServer(self.iserver, self.endpoint.hostname, self.endpoint.port)
             self.bserver.set_policies(self._policies)
+            self.bserver.set_loop(self.iserver.loop)
             self.bserver.start()
         except Exception as exp:
             self.iserver.stop()
@@ -374,6 +376,7 @@ class Server(object):
         for client in self._discovery_clients.values():
             client.disconnect()
         self.bserver.stop()
+        self.bserver.set_loop(None)
         self.iserver.stop()
 
     def get_root_node(self):

--- a/opcua/server/subscription_service.py
+++ b/opcua/server/subscription_service.py
@@ -12,13 +12,16 @@ from opcua.server.internal_subscription import InternalSubscription
 
 class SubscriptionService(object):
 
-    def __init__(self, loop, aspace):
+    def __init__(self, aspace):
         self.logger = logging.getLogger(__name__)
-        self.loop = loop
+        self.loop = None
         self.aspace = aspace
         self.subscriptions = {}
         self._sub_id_counter = 77
         self._lock = RLock()
+
+    def set_loop(self, loop):
+        self.loop = loop
 
     def create_subscription(self, params, callback):
         self.logger.info("create subscription with callback: %s", callback)


### PR DESCRIPTION
#### Fixes #627 
Sorry this is a new PR — for some reason GitHub greyed out the »reopen« button on the old PR.

The various Server objects use a utils.ThreadLoop to handle the
asyncio-mainloop. This Thread(~like) object is not getting
re-initialized in a start()⇒stop()⇒start()-scenario, which leads to a
»Threads may only be started once« exception.

To fix this, we dump the old ThreadLoop object upon re-initialization,
and hand the new object around.