### PR TITLE
Updates asyncio to work with Python 3.7

### DIFF
--- a/opcua/common/utils.py
+++ b/opcua/common/utils.py
@@ -168,7 +168,7 @@ class ThreadLoop(threading.Thread):
 
     def _create_task(self, future, coro, cb=None):
         #task = self.loop.create_task(coro)
-        task = asyncio.async(coro, loop=self.loop) 
+        task = asyncio.ensure_future(coro, loop=self.loop) 
         if cb:
             task.add_done_callback(cb)
         future.set_result(task)


### PR DESCRIPTION
Since Python 3.4.4, `asyncio.async()` has been a deprecated alias to `asyncio.ensure_future()` and in Python 3.7 the`asyncio.async()` alias was removed.