### PR TITLE
Fix reference and parent parsing

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -401,7 +401,6 @@ class XmlImporter(object):
             ref.IsForward = data.forward
             ref.ReferenceTypeId = self.to_nodeid(data.reftype)
             ref.SourceNodeId = self._migrate_ns(obj.nodeid)
-            ref.TargetNodeClass = ua.NodeClass.DataType
             ref.TargetNodeId = self.to_nodeid(data.target)
             refs.append(ref)
         self._add_references(refs)

--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -363,7 +363,10 @@ class NodeManagementService(object):
         rdesc.ReferenceTypeId = addref.ReferenceTypeId
         rdesc.IsForward = addref.IsForward
         rdesc.NodeId = addref.TargetNodeId
-        rdesc.NodeClass = addref.TargetNodeClass
+        if addref.TargetNodeClass == ua.NodeClass.Unspecified:
+            rdesc.NodeClass = self._aspace.get_attribute_value(addref.TargetNodeId, ua.AttributeIds.NodeClass).Value.Value
+        else:
+            rdesc.NodeClass = addref.TargetNodeClass
         bname = self._aspace.get_attribute_value(addref.TargetNodeId, ua.AttributeIds.BrowseName).Value.Value
         if bname:
             rdesc.BrowseName = bname


### PR DESCRIPTION
This reverts 0b6c4d8, because it overwrites the parent for all backward references.

> parent giving as ParentNodeId misses the ref type, so better to prioritize the ref descr

if ParentNodeId is given, I would expect a corresponding backward reference.
I have added a warning if this is not the case. In addtion the parent will be deleted.

As an alternative this special case could be handled later by searching for a corresponding forward reference from the parent..



