### PR TITLE
fixes TimeoutError in KeepAlive thread

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -1,5 +1,6 @@
 from __future__ import division  # support for python2
 from threading import Thread, Condition
+import concurrent.futures
 import logging
 try:
     from urllib.parse import urlparse
@@ -60,8 +61,8 @@ class KeepAlive(Thread):
             self.logger.debug("renewing channel")
             try:
                 self.client.open_secure_channel(renew=True)
-            except ConnectionError as e:
-                self.logger.debug('keepalive failed: {:s}'.format(str(e)))
+            except concurrent.futures.TimeoutError:
+                self.logger.debug("keepalive failed: timeout on open_secure_channel()")
                 break
             val = server_state.get_value()
             self.logger.debug("server state is: %s ", val)

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -58,7 +58,11 @@ class KeepAlive(Thread):
             if self._dostop:
                 break
             self.logger.debug("renewing channel")
-            self.client.open_secure_channel(renew=True)
+            try:
+                self.client.open_secure_channel(renew=True)
+            except ConnectionError as e:
+                self.logger.debug('keepalive failed: {:s}'.format(str(e)))
+                break
             val = server_state.get_value()
             self.logger.debug("server state is: %s ", val)
         self.logger.debug("keepalive thread has stopped")

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -5,7 +5,7 @@ Low level binary client
 import logging
 import socket
 from threading import Thread, Lock
-from concurrent.futures import Future, TimeoutError
+from concurrent.futures import Future
 from functools import partial
 
 from opcua import ua
@@ -173,10 +173,7 @@ class UASocketClient(object):
 
         # FIXME: we have a race condition here
         # we can get a packet with the new token id before we reach to store it..
-        try:
-            response = struct_from_binary(ua.OpenSecureChannelResponse, future.result(self.timeout))
-        except TimeoutError:
-            raise ConnectionError('OpenSecureChannelRequest() timeout')
+        response = struct_from_binary(ua.OpenSecureChannelResponse, future.result(self.timeout))
         response.ResponseHeader.ServiceResult.check()
         self._connection.set_channel(response.Parameters)
         return response.Parameters


### PR DESCRIPTION
https://github.com/FreeOpcUa/python-opcua/issues/664

I took the liberty to throw a more relevant ConnectionError instead of TimeoutError in the open_secure_channel() method. Another option is an ua.UaError derived type?