### PR TITLE
implement support for subscription publishing interval 0

### DIFF
--- a/opcua/server/internal_subscription.py
+++ b/opcua/server/internal_subscription.py
@@ -272,12 +272,17 @@ class InternalSubscription(object):
 
     def start(self):
         self.logger.debug("starting subscription %s", self.data.SubscriptionId)
-        self._subscription_loop()
+        if self.data.RevisedPublishingInterval > 0.0:
+            self._subscription_loop()
 
     def stop(self):
         self.logger.debug("stopping subscription %s", self.data.SubscriptionId)
         self._stopev = True
         self.monitored_item_srv.delete_all_monitored_items()
+
+    def _trigger_publish(self):
+        if not self._stopev and self.data.RevisedPublishingInterval <= 0.0:
+            self.subservice.loop.call_soon(self.publish_results)
 
     def _subscription_loop(self):
         if not self._stopev:
@@ -381,11 +386,13 @@ class InternalSubscription(object):
 
     def enqueue_statuschange(self, code):
         self._triggered_statuschanges.append(code)
+        self._trigger_publish()
 
     def _enqueue_event(self, mid, eventdata, size, queue):
         with self._lock:
             if mid not in queue:
                 queue[mid] = [eventdata]
+                self._trigger_publish()
                 return
             if size != 0:
                 if len(queue[mid]) >= size:


### PR DESCRIPTION
From Part 4 (1.03), 5.12.1.2 
> The Server may support data that is collected based on a sampling model or generated based on
an exception-based model. The fastest supported sampling interval may be equal to 0, which
indicates that the data item is exception-based rather than being sampled at some period.
