### PR TITLE
New classes to support Creating extension objects by users

### DIFF
--- a/examples/server_create_custom_structures.py
+++ b/examples/server_create_custom_structures.py
@@ -1,0 +1,96 @@
+from opcua import ua, Server
+from opcua.common.structure_extension import DataTypeDictionaryBuilder, get_ua_class
+from IPython import embed
+
+
+class DemoServer:
+
+    def __init__(self):
+        self.server = Server()
+
+        self.server.set_endpoint('opc.tcp://0.0.0.0:51210/UA/SampleServer')
+        self.server.set_server_name('Custom structure demo server')
+        # idx name will be used later for creating the xml used in data type dictionary
+        self._idx_name = 'http://examples.freeopcua.github.io'
+        self.idx = self.server.register_namespace(self._idx_name)
+
+        self.dict_builder = DataTypeDictionaryBuilder(self.server, self.idx, self._idx_name, 'MyDictionary')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        quit()
+
+    def start_server(self):
+        self.server.start()
+
+    def create_structure(self, name):
+        # save the created data type
+        data_type_id = self.dict_builder.create_data_type(name)
+        return data_type_id
+
+    def add_field(self, type_name, field_name, struct_name, is_array=False):
+        self.dict_builder.add_field(type_name, field_name, struct_name, is_array)
+
+    def complete_creation(self):
+        self.dict_builder.set_dict_byte_string()
+
+
+if __name__ == '__main__':
+    with DemoServer() as ua_server:
+        # add one basic structure
+        basic_struct_name = 'basic_structure'
+        basic_data_type = ua_server.create_structure(basic_struct_name)
+        ua_server.add_field('Int32', 'ID', basic_struct_name)
+        ua_server.add_field('Boolean', 'Gender', basic_struct_name)
+        ua_server.add_field('String', 'Comments', basic_struct_name)
+
+        # add an advance structure which uses our basic structure
+        nested_struct_name = 'nested_structure'
+        nested_data_type = ua_server.create_structure(nested_struct_name)
+        ua_server.add_field('String', 'Name', nested_struct_name)
+        ua_server.add_field('String', 'Surname', nested_struct_name)
+        ua_server.add_field(basic_struct_name, 'Stuff', nested_struct_name)
+
+        # this operation will write the OPC dict string to our new data type dictionary
+        # namely the 'MyDictionary'
+        ua_server.complete_creation()
+
+        # get the working classes
+        ua_server.server.load_type_definitions()
+
+        # Create one test structure
+        basic_var = ua_server.server.nodes.objects.add_variable(ua.NodeId(namespaceidx=ua_server.idx), 'BasicStruct',
+                                                                ua.Variant(None, ua.VariantType.Null),
+                                                                datatype=basic_data_type)
+
+        basic_var.set_writable()
+        basic_msg = get_ua_class(basic_struct_name)()
+        basic_msg.ID = 3
+        basic_msg.Gender = True
+        basic_msg.Comments = 'Test string'
+        basic_var.set_value(basic_msg)
+
+        # Create one advance test structure
+        nested_var = ua_server.server.nodes.objects.add_variable(ua.NodeId(namespaceidx=ua_server.idx), 'NestedStruct',
+                                                                 ua.Variant(None, ua.VariantType.Null),
+                                                                 datatype=nested_data_type)
+
+        nested_var.set_writable()
+        nested_msg = get_ua_class(nested_struct_name)()
+        nested_msg.Stuff = basic_msg
+        nested_msg.Name = 'Max'
+        nested_msg.Surname = 'Karl'
+        nested_var.set_value(nested_msg)
+
+        ua_server.start_server()
+
+        # see the xml value in our customized dictionary 'MyDictionary', only for debugging use
+        print(getattr(ua_server.dict_builder, '_type_dictionary').get_dict_value())
+
+        # values can be write back and retrieved with the codes below.
+        basic_result = basic_var.get_value()
+        advance_result = nested_var.get_value()
+
+        embed()

--- a/opcua/common/structure_extension.py
+++ b/opcua/common/structure_extension.py
@@ -126,12 +126,8 @@ class DataTypeDictionaryBuilder:
         self.dict_id = self._add_dictionary(dict_name)
         self._type_dictionary = OPCTypeDictionaryBuilder(idx_name)
 
-    def nodeid_generator(self):
-        self._id_counter += 1
-        return ua.NodeId(self._id_counter, namespaceidx=self._idx, nodeidtype=ua.NodeIdType.Numeric)
-
     def _add_dictionary(self, name):
-        dictionary_node_id = self.nodeid_generator()
+        dictionary_node_id = self._nodeid_generator()
         node = ua.AddNodesItem()
         node.RequestedNewNodeId = dictionary_node_id
         node.BrowseName = ua.QualifiedName(name, self._idx)
@@ -149,6 +145,10 @@ class DataTypeDictionaryBuilder:
         self._session_server.add_nodes([node])
 
         return dictionary_node_id
+
+    def _nodeid_generator(self):
+        self._id_counter += 1
+        return ua.NodeId(self._id_counter, namespaceidx=self._idx, nodeidtype=ua.NodeIdType.Numeric)
 
     def _link_nodes(self, linked_obj_node_id, data_type_node_id, description_node_id):
         """link the three node by their node ids according to UA standard"""
@@ -179,12 +179,12 @@ class DataTypeDictionaryBuilder:
                                      ua.NodeId(ua.ObjectIds.HasComponent, 0), False)]
         self._session_server.add_references(refs)
 
-    def create_data_type(self, type_name):
+    def _create_data_type(self, type_name):
         name = _to_camel_case(type_name)
         # apply for new node id
-        data_type_node_id = self.nodeid_generator()
-        description_node_id = self.nodeid_generator()
-        bind_obj_node_id = self.nodeid_generator()
+        data_type_node_id = self._nodeid_generator()
+        description_node_id = self._nodeid_generator()
+        bind_obj_node_id = self._nodeid_generator()
 
         # create data type node
         dt_node = ua.AddNodesItem()
@@ -229,8 +229,10 @@ class DataTypeDictionaryBuilder:
         self._link_nodes(bind_obj_node_id, data_type_node_id, description_node_id)
 
         self._type_dictionary.append_struct(type_name)
-
         return data_type_node_id
+
+    def create_data_type(self, type_name):
+        self._create_data_type(type_name)
 
     def add_field(self, type_name, variable_name, struct_name, is_array=False):
         self._type_dictionary.add_field(type_name, variable_name, struct_name, is_array)

--- a/opcua/common/structure_extension.py
+++ b/opcua/common/structure_extension.py
@@ -20,7 +20,7 @@ def _to_camel_case(name):
     """
     name = re.sub(r'[^a-zA-Z0-9]+', ' ', name)
     name = re.sub('(^|\s)(\S)', _repl_func, name)
-    name = re.sub(r'[^a-zA-Z0-9]+', '', name)
+    name = name.replace(' ', '')
     return name
 
 

--- a/opcua/common/structure_extension.py
+++ b/opcua/common/structure_extension.py
@@ -1,0 +1,243 @@
+from opcua import ua
+
+import xml.etree.ElementTree as Et
+import re
+
+
+def _repl_func(m):
+    """
+    taken from
+     https://stackoverflow.com/questions/1549641/how-to-capitalize-the-first-letter-of-each-word-in-a-string-python
+     """
+    return m.group(1) + m.group(2).upper()
+
+
+def _to_camel_case(name):
+    """
+    Create python class name from an arbitrary string to CamelCase string
+    e.g.                 actionlib/TestAction -> ActionlibTestAction
+         turtle_actionlib/ShapeActionFeedback -> TurtleActionlibShapeActionFeedback
+    """
+    name = re.sub(r'[^a-zA-Z0-9]+', ' ', name)
+    name = re.sub('(^|\s)(\S)', _repl_func, name)
+    name = re.sub(r'[^a-zA-Z0-9]+', '', name)
+    return name
+
+
+class OPCTypeDictionaryBuilder:
+
+    def __init__(self, idx_name, build_in_list):
+        """
+        :param idx_name: name of the name space
+        :param build_in_list: indicates which type should be build in types,
+        types in dict is created as opc:xxx, otherwise as tns:xxx
+        """
+        head_attributes = {'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:tns': idx_name,
+                           'DefaultByteOrder': 'LittleEndian', 'xmlns:opc': 'http://opcfoundation.org/BinarySchema/',
+                           'xmlns:ua': 'http://opcfoundation.org/UA/', 'TargetNamespace': idx_name}
+
+        self.etree = Et.ElementTree(Et.Element('opc:TypeDictionary', head_attributes))
+
+        name_space = Et.SubElement(self.etree.getroot(), 'opc:Import')
+        name_space.attrib['Namespace'] = 'http://opcfoundation.org/UA/'
+
+        self._structs_dict = {}
+        self._build_in_list = build_in_list
+
+    def _add_field(self, type_name, variable_name, struct_name):
+        if type_name in self._build_in_list:
+            type_name = 'opc:' + type_name
+        else:
+            type_name = 'tns:' + _to_camel_case(type_name)
+        field = Et.SubElement(self._structs_dict[struct_name], 'opc:Field')
+        field.attrib['Name'] = variable_name
+        field.attrib['TypeName'] = type_name
+
+    def _add_array_field(self, type_name, variable_name, struct_name):
+        if type_name in self._build_in_list:
+            type_name = 'opc:' + type_name
+        else:
+            type_name = 'tns:' + _to_camel_case(type_name)
+        array_len = 'NoOf' + variable_name
+        field = Et.SubElement(self._structs_dict[struct_name], 'opc:Field')
+        field.attrib['Name'] = array_len
+        field.attrib['TypeName'] = 'opc:Int32'
+        field = Et.SubElement(self._structs_dict[struct_name], 'opc:Field')
+        field.attrib['Name'] = variable_name
+        field.attrib['TypeName'] = type_name
+        field.attrib['LengthField'] = array_len
+
+    def add_field(self, type_name, variable_name, struct_name, is_array=False):
+        if is_array:
+            self._add_array_field(type_name, variable_name, struct_name)
+        else:
+            self._add_field(type_name, variable_name, struct_name)
+
+    def append_struct(self, name):
+        appended_struct = Et.SubElement(self.etree.getroot(), 'opc:StructuredType')
+        appended_struct.attrib['BaseType'] = 'ua:ExtensionObject'
+        appended_struct.attrib['Name'] = _to_camel_case(name)
+        self._structs_dict[name] = appended_struct
+        return appended_struct
+
+    def get_dict_value(self):
+        self.indent(self.etree.getroot())
+        # For debugging
+        # Et.dump(self.etree.getroot())
+        return Et.tostring(self.etree.getroot(), encoding='utf-8')
+
+    def indent(self, elem, level=0):
+        i = '\n' + level * '  '
+        if len(elem):
+            if not elem.text or not elem.text.strip():
+                elem.text = i + '  '
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+            for elem in elem:
+                self.indent(elem, level + 1)
+            if not elem.tail or not elem.tail.strip():
+                elem.tail = i
+        else:
+            if level and (not elem.tail or not elem.tail.strip()):
+                elem.tail = i
+
+
+class DataTypeDictionaryBuilder:
+
+    def __init__(self, server, idx, idx_name, dict_name):
+        self._server = server
+        self._session_server = server.get_root_node().server
+        self._idx = idx
+        # Risk of bugs using a fixed number without checking
+        self._id_counter = 8000
+        self.dict_id = self._add_dictionary(dict_name)
+        ua_build_in_types = [item for item in ua.VariantType.__members__ if item != 'ExtensionObject']
+        self._type_dictionary = OPCTypeDictionaryBuilder(idx_name, ua_build_in_types)
+
+    def nodeid_generator(self):
+        self._id_counter += 1
+        return ua.NodeId(self._id_counter, namespaceidx=self._idx, nodeidtype=ua.NodeIdType.Numeric)
+
+    def _add_dictionary(self, name):
+        dictionary_node_id = self.nodeid_generator()
+        node = ua.AddNodesItem()
+        node.RequestedNewNodeId = dictionary_node_id
+        node.BrowseName = ua.QualifiedName(name, self._idx)
+        node.NodeClass = ua.NodeClass.Variable
+        node.ParentNodeId = ua.NodeId(ua.ObjectIds.OPCBinarySchema_TypeSystem, 0)
+        node.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasComponent, 0)
+        node.TypeDefinition = ua.NodeId(ua.ObjectIds.DataTypeDictionaryType, 0)
+        attrs = ua.VariableAttributes()
+        attrs.DisplayName = ua.LocalizedText(name)
+        attrs.DataType = ua.NodeId(ua.ObjectIds.ByteString)
+        # Value should be set after all data types created by calling set_dict_byte_string
+        attrs.Value = ua.Variant(None, ua.VariantType.Null)
+        attrs.ValueRank = -1
+        node.NodeAttributes = attrs
+        self._session_server.add_nodes([node])
+
+        return dictionary_node_id
+
+    @staticmethod
+    def _reference_generator(source_id, target_id, reference_type, is_forward=True):
+        ref = ua.AddReferencesItem()
+        ref.IsForward = is_forward
+        ref.ReferenceTypeId = reference_type
+        ref.SourceNodeId = source_id
+        ref.TargetNodeClass = ua.NodeClass.DataType
+        ref.TargetNodeId = target_id
+        return ref
+
+    def _link_nodes(self, linked_obj_node_id, data_type_node_id, description_node_id):
+        """link the three node by their node ids according to UA standard"""
+        refs = [
+                # add reverse reference to BaseDataType -> Structure
+                self._reference_generator(data_type_node_id, ua.NodeId(ua.ObjectIds.Structure, 0),
+                                          ua.NodeId(ua.ObjectIds.HasSubtype, 0), False),
+                # add reverse reference to created data type
+                self._reference_generator(linked_obj_node_id, data_type_node_id,
+                                          ua.NodeId(ua.ObjectIds.HasEncoding, 0), False),
+                # add HasDescription link to dictionary description
+                self._reference_generator(linked_obj_node_id, description_node_id,
+                                          ua.NodeId(ua.ObjectIds.HasDescription, 0)),
+                # add reverse HasDescription link
+                self._reference_generator(description_node_id, linked_obj_node_id,
+                                          ua.NodeId(ua.ObjectIds.HasDescription, 0), False),
+                # add link to the type definition node
+                self._reference_generator(linked_obj_node_id, ua.NodeId(ua.ObjectIds.DataTypeEncodingType, 0),
+                                          ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
+                # add has type definition link
+                self._reference_generator(description_node_id, ua.NodeId(ua.ObjectIds.DataTypeDescriptionType, 0),
+                                          ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
+                # add forward link of dict to description item
+                self._reference_generator(self.dict_id, description_node_id,
+                                          ua.NodeId(ua.ObjectIds.HasComponent, 0)),
+                # add reverse link to dictionary
+                self._reference_generator(description_node_id, self.dict_id,
+                                          ua.NodeId(ua.ObjectIds.HasComponent, 0), False)]
+        self._session_server.add_references(refs)
+
+    def create_data_type(self, type_name):
+        name = _to_camel_case(type_name)
+        # apply for new node id
+        data_type_node_id = self.nodeid_generator()
+        description_node_id = self.nodeid_generator()
+        bind_obj_node_id = self.nodeid_generator()
+
+        # create data type node
+        dt_node = ua.AddNodesItem()
+        dt_node.RequestedNewNodeId = data_type_node_id
+        dt_node.BrowseName = ua.QualifiedName(name, self._idx)
+        dt_node.NodeClass = ua.NodeClass.DataType
+        dt_node.ParentNodeId = ua.NodeId(ua.ObjectIds.Structure, 0)
+        dt_node.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasSubtype, 0)
+        dt_attributes = ua.DataTypeAttributes()
+        dt_attributes.DisplayName = ua.LocalizedText(type_name)
+        dt_node.NodeAttributes = dt_attributes
+
+        # create description node
+        desc_node = ua.AddNodesItem()
+        desc_node.RequestedNewNodeId = description_node_id
+        desc_node.BrowseName = ua.QualifiedName(name, self._idx)
+        desc_node.NodeClass = ua.NodeClass.Variable
+        desc_node.ParentNodeId = self.dict_id
+        desc_node.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasComponent, 0)
+        desc_node.TypeDefinition = ua.NodeId(ua.ObjectIds.DataTypeDescriptionType, 0)
+        desc_attributes = ua.VariableAttributes()
+        desc_attributes.DisplayName = ua.LocalizedText(type_name)
+        desc_attributes.DataType = ua.NodeId(ua.ObjectIds.String)
+        desc_attributes.Value = ua.Variant(name, ua.VariantType.String)
+        desc_attributes.ValueRank = -1
+        desc_node.NodeAttributes = desc_attributes
+
+        # create object node which the loaded python class should link to
+        obj_node = ua.AddNodesItem()
+        obj_node.RequestedNewNodeId = bind_obj_node_id
+        obj_node.BrowseName = ua.QualifiedName('Default Binary', 0)
+        obj_node.NodeClass = ua.NodeClass.Object
+        obj_node.ParentNodeId = data_type_node_id
+        obj_node.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasEncoding, 0)
+        obj_node.TypeDefinition = ua.NodeId(ua.ObjectIds.DataTypeEncodingType, 0)
+        obj_attributes = ua.ObjectAttributes()
+        obj_attributes.DisplayName = ua.LocalizedText('Default Binary')
+        obj_attributes.EventNotifier = 0
+        obj_node.NodeAttributes = obj_attributes
+
+        self._session_server.add_nodes([dt_node, desc_node, obj_node])
+        self._link_nodes(bind_obj_node_id, data_type_node_id, description_node_id)
+
+        self._type_dictionary.append_struct(type_name)
+
+        return data_type_node_id
+
+    def add_field(self, type_name, variable_name, struct_name, is_array=False):
+        self._type_dictionary.add_field(type_name, variable_name, struct_name, is_array)
+
+    def set_dict_byte_string(self):
+        dict_node = self._server.get_node(self.dict_id)
+        value = self._type_dictionary.get_dict_value()
+        dict_node.set_value(value, ua.VariantType.ByteString)
+
+
+def get_ua_class(ua_class_name):
+    return getattr(ua, _to_camel_case(ua_class_name))

--- a/opcua/common/structure_extension.py
+++ b/opcua/common/structure_extension.py
@@ -3,6 +3,9 @@ from opcua import ua
 import xml.etree.ElementTree as Et
 import re
 
+# Indicates which type should be OPC build in types
+_ua_build_in_types = [ua_type for ua_type in ua.VariantType.__members__ if ua_type != 'ExtensionObject']
+
 
 def _repl_func(m):
     """
@@ -26,10 +29,9 @@ def _to_camel_case(name):
 
 class OPCTypeDictionaryBuilder:
 
-    def __init__(self, idx_name, build_in_list):
+    def __init__(self, idx_name):
         """
         :param idx_name: name of the name space
-        :param build_in_list: indicates which type should be build in types,
         types in dict is created as opc:xxx, otherwise as tns:xxx
         """
         head_attributes = {'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:tns': idx_name,
@@ -42,22 +44,23 @@ class OPCTypeDictionaryBuilder:
         name_space.attrib['Namespace'] = 'http://opcfoundation.org/UA/'
 
         self._structs_dict = {}
-        self._build_in_list = build_in_list
-
-    def _add_field(self, type_name, variable_name, struct_name):
+        self._build_in_list = _ua_build_in_types
+    
+    def _process_type(self, type_name):
         if type_name in self._build_in_list:
             type_name = 'opc:' + type_name
         else:
             type_name = 'tns:' + _to_camel_case(type_name)
+        return type_name
+
+    def _add_field(self, type_name, variable_name, struct_name):
+        type_name = self._process_type(type_name)
         field = Et.SubElement(self._structs_dict[struct_name], 'opc:Field')
         field.attrib['Name'] = variable_name
         field.attrib['TypeName'] = type_name
 
     def _add_array_field(self, type_name, variable_name, struct_name):
-        if type_name in self._build_in_list:
-            type_name = 'opc:' + type_name
-        else:
-            type_name = 'tns:' + _to_camel_case(type_name)
+        type_name = self._process_type(type_name)
         array_len = 'NoOf' + variable_name
         field = Et.SubElement(self._structs_dict[struct_name], 'opc:Field')
         field.attrib['Name'] = array_len
@@ -102,6 +105,16 @@ class OPCTypeDictionaryBuilder:
                 elem.tail = i
 
 
+def _reference_generator(source_id, target_id, reference_type, is_forward=True):
+    ref = ua.AddReferencesItem()
+    ref.IsForward = is_forward
+    ref.ReferenceTypeId = reference_type
+    ref.SourceNodeId = source_id
+    ref.TargetNodeClass = ua.NodeClass.DataType
+    ref.TargetNodeId = target_id
+    return ref
+
+
 class DataTypeDictionaryBuilder:
 
     def __init__(self, server, idx, idx_name, dict_name):
@@ -111,8 +124,7 @@ class DataTypeDictionaryBuilder:
         # Risk of bugs using a fixed number without checking
         self._id_counter = 8000
         self.dict_id = self._add_dictionary(dict_name)
-        ua_build_in_types = [item for item in ua.VariantType.__members__ if item != 'ExtensionObject']
-        self._type_dictionary = OPCTypeDictionaryBuilder(idx_name, ua_build_in_types)
+        self._type_dictionary = OPCTypeDictionaryBuilder(idx_name)
 
     def nodeid_generator(self):
         self._id_counter += 1
@@ -138,43 +150,33 @@ class DataTypeDictionaryBuilder:
 
         return dictionary_node_id
 
-    @staticmethod
-    def _reference_generator(source_id, target_id, reference_type, is_forward=True):
-        ref = ua.AddReferencesItem()
-        ref.IsForward = is_forward
-        ref.ReferenceTypeId = reference_type
-        ref.SourceNodeId = source_id
-        ref.TargetNodeClass = ua.NodeClass.DataType
-        ref.TargetNodeId = target_id
-        return ref
-
     def _link_nodes(self, linked_obj_node_id, data_type_node_id, description_node_id):
         """link the three node by their node ids according to UA standard"""
         refs = [
                 # add reverse reference to BaseDataType -> Structure
-                self._reference_generator(data_type_node_id, ua.NodeId(ua.ObjectIds.Structure, 0),
-                                          ua.NodeId(ua.ObjectIds.HasSubtype, 0), False),
+                _reference_generator(data_type_node_id, ua.NodeId(ua.ObjectIds.Structure, 0),
+                                     ua.NodeId(ua.ObjectIds.HasSubtype, 0), False),
                 # add reverse reference to created data type
-                self._reference_generator(linked_obj_node_id, data_type_node_id,
-                                          ua.NodeId(ua.ObjectIds.HasEncoding, 0), False),
+                _reference_generator(linked_obj_node_id, data_type_node_id,
+                                     ua.NodeId(ua.ObjectIds.HasEncoding, 0), False),
                 # add HasDescription link to dictionary description
-                self._reference_generator(linked_obj_node_id, description_node_id,
-                                          ua.NodeId(ua.ObjectIds.HasDescription, 0)),
+                _reference_generator(linked_obj_node_id, description_node_id,
+                                     ua.NodeId(ua.ObjectIds.HasDescription, 0)),
                 # add reverse HasDescription link
-                self._reference_generator(description_node_id, linked_obj_node_id,
-                                          ua.NodeId(ua.ObjectIds.HasDescription, 0), False),
+                _reference_generator(description_node_id, linked_obj_node_id,
+                                     ua.NodeId(ua.ObjectIds.HasDescription, 0), False),
                 # add link to the type definition node
-                self._reference_generator(linked_obj_node_id, ua.NodeId(ua.ObjectIds.DataTypeEncodingType, 0),
-                                          ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
+                _reference_generator(linked_obj_node_id, ua.NodeId(ua.ObjectIds.DataTypeEncodingType, 0),
+                                     ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
                 # add has type definition link
-                self._reference_generator(description_node_id, ua.NodeId(ua.ObjectIds.DataTypeDescriptionType, 0),
-                                          ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
+                _reference_generator(description_node_id, ua.NodeId(ua.ObjectIds.DataTypeDescriptionType, 0),
+                                     ua.NodeId(ua.ObjectIds.HasTypeDefinition, 0)),
                 # add forward link of dict to description item
-                self._reference_generator(self.dict_id, description_node_id,
-                                          ua.NodeId(ua.ObjectIds.HasComponent, 0)),
+                _reference_generator(self.dict_id, description_node_id,
+                                     ua.NodeId(ua.ObjectIds.HasComponent, 0)),
                 # add reverse link to dictionary
-                self._reference_generator(description_node_id, self.dict_id,
-                                          ua.NodeId(ua.ObjectIds.HasComponent, 0), False)]
+                _reference_generator(description_node_id, self.dict_id,
+                                     ua.NodeId(ua.ObjectIds.HasComponent, 0), False)]
         self._session_server.add_references(refs)
 
     def create_data_type(self, type_name):


### PR DESCRIPTION
## Motivation

In my [use case](https://github.com/iirob/ros_opcua_communication/tree/interactive_ros/ros_opcua_impl_python_opcua) I need to read some external structures and create extension objects from them on-the-fly, I wrote two classes to support this as an extension of the standard python-opcua package. 

But I've seen that there are some other discussions to request this function in the python-opcua package, and in #388 there are two TODOs open:

server:
- [ ] add a method that generates the xml (to be used in code and by opcua-modeler)
- [ ] add a method that creates the necessary data types nodes

 which could correspondent to my classes `OPCTypeDictionaryBuilder` and  `DataTypeDictionaryBuilder`, therefore I created this pull request. 

Please first **Do Not Merge**, since I am not sure where you would like to put them in the project, I would suggest to put them in `opcua/common/structures.py`.

## The new classes

### Class `OPCTypeDictionaryBuilder`:
Generates xml files from a structure definition. The result of the xml string generated in the example `examples/server_create_custom_structures.py` is like this:
```xml
<opc:TypeDictionary DefaultByteOrder="LittleEndian" TargetNamespace="http://examples.freeopcua.github.io" xmlns:opc="http://opcfoundation.org/BinarySchema/" xmlns:tns="http://examples.freeopcua.github.io" xmlns:ua="http://opcfoundation.org/UA/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <opc:Import Namespace="http://opcfoundation.org/UA/" />
  <opc:StructuredType BaseType="ua:ExtensionObject" Name="BasicStructure">
    <opc:Field Name="ID" TypeName="opc:Int32" />
    <opc:Field Name="Gender" TypeName="opc:Boolean" />
    <opc:Field Name="Comments" TypeName="opc:String" />
  </opc:StructuredType>
  <opc:StructuredType BaseType="ua:ExtensionObject" Name="NestedStructure">
    <opc:Field Name="Name" TypeName="opc:String" />
    <opc:Field Name="Surname" TypeName="opc:String" />
    <opc:Field Name="Stuff" TypeName="tns:BasicStructure" />
  </opc:StructuredType>
</opc:TypeDictionary>
```

The `append_struct` method creates a new structure frame, and the `add_field` method allows to add structure members it the structure frame. The `get_dict_value` method retrieves the created xml string.

### One possible question

Maybe there is a question, why is there another parameter `struct_name` in `add_field` function, since we know after the structure creation we will directly add fields to the structure just then added?

The answer is to make the life easier for the users who use recursion to traverse some files or strings and create ua structures, for instance in my use case. But another method could be provided without the parameter `struct_name` in `add_field` function so that the users directly add structure members to it after the structure frame is created.

### Class `DataTypeDictionaryBuilder`

This class creates an `OPC Binary Dictionary` of the newly created extension objects. The result in the example `examples/server_create_custom_structures.py` is like this in the tool `UaExpert`:
![built binary dictionary](https://user-images.githubusercontent.com/16988853/44331912-0f4d9a00-a46b-11e8-848d-2f42f0afeab6.png)

This class has an internal `OPCTypeDictionaryBuilder` object, so as to automate the xml creation. 

The `create_data_type` method is to create new structure frame, and the `add_field` is to add structure members to the new structure frame. 

The `set_dict_byte_string` method will set the xml string created by the internal `OPCTypeDictionaryBuilder` object to the created dictionary, in the example case, it is the `MyDictionary` shown in the picture above. By this way, the standard UA tools like `UaExpert` can also correctly parsing the newly created objects. Below are two pics to show the result of the example.

The user could see the value of the extension objects in the attribute window directly:
![value in attributes](https://user-images.githubusercontent.com/16988853/44332912-956ae000-a46d-11e8-83f4-16e8b1cb0dbc.png)

Or by double-clicking the value in the data access view:
![value in data access view](https://user-images.githubusercontent.com/16988853/44332991-c9de9c00-a46d-11e8-991a-da571a74836b.png)

### Another possible question

Maybe there is another question, why not use the standard functions `Node.add_data_type`, `Node.add_variable` and `add_object` instead of directly creating nodes with some low level functions?

Since the dictionary uses quite different node types and reference types, for instance:

The dictionary description node is a ua variable, it has this type definition:

```python
desc_node.TypeDefinition = ua.NodeId(ua.ObjectIds.DataTypeDescriptionType, 0)
```

And for the object node, it has even different reference types:

```python
obj_node.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasEncoding, 0)
obj_node.TypeDefinition = ua.NodeId(ua.ObjectIds.DataTypeEncodingType, 0)
```

And the references inside the data types and dictionary are complex to program with the standard methods.

## The naming problem in `opcua/common/structures.py`

1. In `opcua/common/structures.py` the original method `_clean_name` (line 283) removes the illegal chars in the class name, but the user does not know the name changes afterward. Therefore the user could not locate the created class by the given name.

2. The method `_clean_name` only removes the illegal chars but does not make it to the python conventional camel case.

I would suggest using the method `_to_camel_case` in the `opcua/common/structure_extension.py`, it removes the illegal chars and makes the name string in camel case without damaging the original camel case in the string.

For example: `turtle_actionlib/ShapeActionFeedback -> TurtleActionlibShapeActionFeedback`, the original camel case in the part `ShapeActionFeedback` is kept with this method.

I also used `_to_camel_case` in designing `OPCTypeDictionaryBuilder` and  `DataTypeDictionaryBuilder`, so that the created extension objects could be directly used for generating python classes. In the UA nodes, the browser name will be modified by the `_to_camel_case` function to camel case, while the display name is set to the user given name, which makes the nodes identifiable for the users.

To solve problem 1, the `get_ua_class` method could be used (see example), each time if the user wants to use one specific class,  the method with the user given name will yield the generated class.

```python
my_ext_class = get_ua_class('turtle_actionlib/ShapeActionFeedback')
my_ext_obj = my_ext_class()
```

The `/structure_extension.py` is tested with the example, and with my use case, which includes more than 1,000 newly created structures, some structures are nested in several layers, some structures have structures lists.