### PR TITLE
Add support for server username/password auth

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -313,13 +313,13 @@ class InternalServer(object):
                 self.logger.warning("Unable to decrypt password")
                 return False
 
-        # call user manager if one is defined
+        # call user_manager if one is defined
         if self.user_manager is not None:
             return self.user_manager(self, isession, userName, passwd)
 
-        # do the default thing
+        # If nothing function defined, do the default thing
         if self.allow_remote_admin and userName in ("admin", "Admin"):
-                isession.user = User.Admin
+            isession.user = User.Admin
         return True
 
 

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -464,9 +464,3 @@ class InternalSession(object):
             acks = []
         return self.subscription_service.publish(acks)
 
-
-def default_user_manager(self, iserver, isession, username, password):
-    if self.allow_remote_admin and username in ("admin", "Admin"):
-        isession.user = User.Admin
-    return True        
-

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -663,7 +663,7 @@ class Server(object):
         pw = token.Password
 
         # decrypt password is we can
-        if token.EncryptionAlgorithm != "None":
+        if str(token.EncryptionAlgorithm) != "None":
             if use_crypto == False:
                 return False;
             try:
@@ -672,14 +672,14 @@ class Server(object):
                 elif token.EncryptionAlgorithm == "http://www.w3.org/2001/04/xmlenc#rsa-oaep":
                     raw_pw = uacrypto.decrypt_rsa_oaep(self.private_key, pw)
                 else:
-                    self.logger.warning("Unknown password encoding: {0}".format(token.EncryptionAlgorithm))
+                    self.logger.warning("Unknown password encoding '{0}'".format(token.EncryptionAlgorithm))
                     return False
 
                 nonce_len = 32
                 length = unpack_from('<I', raw_pw)[0] - nonce_len
-                pw = raw_pw[4:4 + length].decode('utf-8')
+                pw = raw_pw[4:4 + length]
             except Exception as exp:
                 self.logger.warning("Unable to decrypt password")
                 return False
 
-        return self.user_manager(token.UserName, pw)
+        return self.user_manager(str(token.UserName), pw.decode('utf-8'))


### PR DESCRIPTION
This change adds support for username/password authentication to the server via new server.set_user_manager(user_manager) function.  The user_manager function takes two arguments, namely a username and password, and returns a boolean indicating if access should be granted.