### PR TITLE
Make sure NodeClass attribute is of type UInt32

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -257,7 +257,7 @@ class NodeManagementService(object):
             ua.DataValue(ua.Variant(item.BrowseName, ua.VariantType.QualifiedName))
         )
         nodedata.attributes[ua.AttributeIds.NodeClass] = AttributeValue(
-            ua.DataValue(ua.Variant(item.NodeClass, ua.VariantType.Int32))
+            ua.DataValue(ua.Variant(item.NodeClass, ua.VariantType.UInt32))
         )
         # add requested attrs
         self._add_nodeattributes(item.NodeAttributes, nodedata, add_timestamps)


### PR DESCRIPTION
All other places use UInt32 for NodeClass. Make sure this is consistent.