### PR TITLE
Make recursive node deletion truly recursive

### DIFF
--- a/opcua/common/manage_nodes.py
+++ b/opcua/common/manage_nodes.py
@@ -379,7 +379,7 @@ def delete_nodes(server, nodes, recursive=False, delete_target_references=True):
     """
     nodestodelete = []
     if recursive:
-        nodes += _add_childs(nodes)
+        nodes = _add_childs(nodes)
     for mynode in nodes:
         it = ua.DeleteNodesItem()
         it.NodeId = mynode.nodeid
@@ -392,8 +392,9 @@ def delete_nodes(server, nodes, recursive=False, delete_target_references=True):
 
 def _add_childs(nodes):
     results = []
-    for mynode in nodes[:]:
-        results += mynode.get_children()
+    for mynode in nodes:
+        results += _add_childs(mynode.get_children())
+        results += [mynode]
     return results
 
 

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -139,10 +139,14 @@ class CommonTests(object):
             var = fold.add_property(2, "ProToDeleteR", 9.1)
             prop = fold.add_property(2, "ProToDeleteR", 9.1)
             o = fold.add_object(3, "ObjToDeleteR")
+            o_var = o.add_variable(3, "VarToDeleteRR", 9.2)
+            o_prop = o.add_property(3, "PropToDeleteRR", 9.2)
             mynodes.append(nfold)
             mynodes.append(var)
             mynodes.append(prop)
             mynodes.append(o)
+            mynodes.append(o_var)
+            mynodes.append(o_prop)
         self.opc.delete_nodes([fold], recursive=True)
         for node in mynodes:
             with self.assertRaises(ua.UaStatusCodeError):


### PR DESCRIPTION
Fixes #694 

Before it only deleted the first level of nodes below the specified
list, which was not what the parameter `recursive` conveyed to the user.

This also adds a test, which failed in current master, but succeeds in this branch.