### PR TITLE
Removed security policies with Sha-1 algorithm

### DIFF
--- a/examples/client_to_prosys.py
+++ b/examples/client_to_prosys.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     client = Client("opc.tcp://localhost:53530/OPCUA/SimulationServer/")
     #client = Client("opc.tcp://olivier:olivierpass@localhost:53530/OPCUA/SimulationServer/")
-    #client.set_security_string("Basic256,SignAndEncrypt,certificate-example.der,private-key-example.pem")
+    #client.set_security_string("Basic256Sha256,SignAndEncrypt,certificate-example.der,private-key-example.pem")
     try:
         client.connect()
         root = client.get_root_node()

--- a/examples/client_to_prosys_crypto.py
+++ b/examples/client_to_prosys_crypto.py
@@ -10,7 +10,7 @@ from opcua import Client
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     client = Client("opc.tcp://localhost:53530/OPCUA/SimulationServer/")
-    client.set_security_string("Basic256,Sign,certificate-example.der,private-key-example.pem")
+    client.set_security_string("Basic256Sha256,Sign,certificate-example.der,private-key-example.pem")
     try:
         client.connect()
         root = client.get_root_node()

--- a/examples/server-example.py
+++ b/examples/server-example.py
@@ -91,10 +91,8 @@ if __name__ == "__main__":
     # set all possible endpoint policies for clients to connect through
     server.set_security_policy([
                 ua.SecurityPolicyType.NoSecurity,
-                ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt,
-                ua.SecurityPolicyType.Basic128Rsa15_Sign,
-                ua.SecurityPolicyType.Basic256_SignAndEncrypt,
-                ua.SecurityPolicyType.Basic256_Sign])
+                ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt,
+                ua.SecurityPolicyType.Basic256Sha256_Sign])
 
     # setup our own namespace
     uri = "http://examples.freeopcua.github.io"

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -159,7 +159,7 @@ class Client(object):
         """
         Set SecureConnection mode. String format:
         Policy,Mode,certificate,private_key[,server_private_key]
-        where Policy is Basic128Rsa15 or Basic256,
+        where Policy is Basic128Rsa15, Basic256 or Basic256Sha256,
             Mode is Sign or SignAndEncrypt
             certificate, private_key and server_private_key are
                 paths to .pem or .der files

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -116,12 +116,10 @@ class Server(object):
         # enable all endpoints by default
         self._security_policy = [
                         ua.SecurityPolicyType.NoSecurity,
-                        ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt,
-                        ua.SecurityPolicyType.Basic128Rsa15_Sign,
-                        ua.SecurityPolicyType.Basic256_SignAndEncrypt,
-                        ua.SecurityPolicyType.Basic256_Sign
+                        ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt,
+                        ua.SecurityPolicyType.Basic256Sha256_Sign
                                 ]
-        self._policyIDs = ["Anonymous", "Basic256", "Basic128", "Username"]
+        self._policyIDs = ["Anonymous", "Basic256Sha256", "Username"]
 
     def __enter__(self):
         self.start()
@@ -231,17 +229,14 @@ class Server(object):
 
                 security_policy = [
                             ua.SecurityPolicyType.NoSecurity,
-                            ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt,
-                            ua.SecurityPolicyType.Basic128Rsa15_Sign,
-                            ua.SecurityPolicyType.Basic256_SignAndEncrypt,
-                            ua.SecurityPolicyType.Basic256_Sign
+                            ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt,
+                            ua.SecurityPolicyType.Basic256Sha256_Sign
                                 ]
 
             E.g. to limit the number of endpoints and disable no encryption:
 
                 set_security_policy([
-                            ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt
-                            ua.SecurityPolicyType.Basic256_SignAndEncrypt])
+                            ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt])
 
         """
         self._security_policy = security_policy
@@ -249,14 +244,14 @@ class Server(object):
     def set_security_IDs(self, policyIDs):
         """
             Method setting up the security endpoints for identification
-            of clients. During server object initialization, all possible 
+            of clients. During server object initialization, all possible
             endpoints are enabled:
 
-            self._policyIDs = ["Anonymous", "Basic256", "Basic128", "Username"]
+            self._policyIDs = ["Anonymous", "Basic256Sha256", "Username"]
 
             E.g. to limit the number of IDs and disable anonymous clients:
 
-                set_security_policy(["Basic256"])
+                set_security_policy(["Basic256Sha256"])
 
             (Implementation for ID check is currently not finalized...)
 
@@ -277,34 +272,18 @@ class Server(object):
             if ua.SecurityPolicyType.NoSecurity in self._security_policy:
                 self.logger.warning("Creating an open endpoint to the server, although encrypted endpoints are enabled.")
 
-            if ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt in self._security_policy:
-                self._set_endpoints(security_policies.SecurityPolicyBasic128Rsa15,
+            if ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt in self._security_policy:
+                self._set_endpoints(security_policies.SecurityPolicyBasic256Sha256,
                                     ua.MessageSecurityMode.SignAndEncrypt)
-                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic128Rsa15,
+                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic256Sha256,
                                                                ua.MessageSecurityMode.SignAndEncrypt,
                                                                self.certificate,
                                                                self.private_key)
                                      )
-            if ua.SecurityPolicyType.Basic128Rsa15_Sign in self._security_policy:
-                self._set_endpoints(security_policies.SecurityPolicyBasic128Rsa15,
+            if ua.SecurityPolicyType.Basic256Sha256_Sign in self._security_policy:
+                self._set_endpoints(security_policies.SecurityPolicyBasic256Sha256,
                                     ua.MessageSecurityMode.Sign)
-                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic128Rsa15,
-                                                               ua.MessageSecurityMode.Sign,
-                                                               self.certificate,
-                                                               self.private_key)
-                                     )
-            if ua.SecurityPolicyType.Basic256_SignAndEncrypt in self._security_policy:
-                self._set_endpoints(security_policies.SecurityPolicyBasic256,
-                                    ua.MessageSecurityMode.SignAndEncrypt)
-                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic256,
-                                                               ua.MessageSecurityMode.SignAndEncrypt,
-                                                               self.certificate,
-                                                               self.private_key)
-                                     )
-            if ua.SecurityPolicyType.Basic256_Sign in self._security_policy:
-                self._set_endpoints(security_policies.SecurityPolicyBasic256,
-                                    ua.MessageSecurityMode.Sign)
-                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic256,
+                self._policies.append(ua.SecurityPolicyFactory(security_policies.SecurityPolicyBasic256Sha256,
                                                                ua.MessageSecurityMode.Sign,
                                                                self.certificate,
                                                                self.private_key)
@@ -318,15 +297,9 @@ class Server(object):
             idtoken.TokenType = ua.UserTokenType.Anonymous
             idtokens.append(idtoken)
 
-        if "Basic256" in self._policyIDs:
+        if "Basic256Sha256" in self._policyIDs:
             idtoken = ua.UserTokenPolicy()
-            idtoken.PolicyId = 'certificate_basic256'
-            idtoken.TokenType = ua.UserTokenType.Certificate
-            idtokens.append(idtoken)
-
-        if "Basic128" in self._policyIDs:
-            idtoken = ua.UserTokenPolicy()
-            idtoken.PolicyId = 'certificate_basic128'
+            idtoken.PolicyId = 'certificate_basic256sha256'
             idtoken.TokenType = ua.UserTokenType.Certificate
             idtokens.append(idtoken)
 

--- a/opcua/tools.py
+++ b/opcua/tools.py
@@ -60,7 +60,7 @@ def add_common_args(parser, default_node='i=84', require_node=False):
                         default=0,
                         metavar="NAMESPACE")
     parser.add_argument("--security",
-                        help="Security settings, for example: Basic256,SignAndEncrypt,cert.der,pk.pem[,server_cert.der]. Default: None",
+                        help="Security settings, for example: Basic256Sha256,SignAndEncrypt,cert.der,pk.pem[,server_cert.der]. Default: None",
                         default='')
     parser.add_argument("--user",
                         help="User name for authentication. Overrides the user name given in the URL.")

--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -968,6 +968,8 @@ class SecurityPolicyType(Enum):
     "Basic128Rsa15_SignAndEncrypt"
     "Basic256_Sign"
     "Basic256_SignAndEncrypt"
+    "Basic256Sha256_Sign"
+    "Basic256Sha256_SignAndEncrypt"
 
     """
 
@@ -976,3 +978,5 @@ class SecurityPolicyType(Enum):
     Basic128Rsa15_SignAndEncrypt = 2
     Basic256_Sign = 3
     Basic256_SignAndEncrypt = 4
+    Basic256Sha256_Sign = 5
+    Basic256Sha256_SignAndEncrypt = 6

--- a/tests/tests_crypto_connect.py
+++ b/tests/tests_crypto_connect.py
@@ -25,28 +25,28 @@ class TestCryptoConnect(unittest.TestCase):
 
     '''
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(self):
         # start our own server
-        cls.srv_crypto = Server()
-        cls.uri_crypto = 'opc.tcp://127.0.0.1:{0:d}'.format(port_num1)
-        cls.srv_crypto.set_endpoint(cls.uri_crypto)
+        self.srv_crypto = Server()
+        self.uri_crypto = 'opc.tcp://127.0.0.1:{0:d}'.format(port_num1)
+        self.srv_crypto.set_endpoint(self.uri_crypto)
         # load server certificate and private key. This enables endpoints
         # with signing and encryption.
-        cls.srv_crypto.load_certificate("examples/certificate-example.der")
-        cls.srv_crypto.load_private_key("examples/private-key-example.pem")
-        cls.srv_crypto.start()
+        self.srv_crypto.load_certificate("examples/certificate-example.der")
+        self.srv_crypto.load_private_key("examples/private-key-example.pem")
+        self.srv_crypto.start()
 
         # start a server without crypto
-        cls.srv_no_crypto = Server()
-        cls.uri_no_crypto = 'opc.tcp://127.0.0.1:{0:d}'.format(port_num2)
-        cls.srv_no_crypto.set_endpoint(cls.uri_no_crypto)
-        cls.srv_no_crypto.start()
+        self.srv_no_crypto = Server()
+        self.uri_no_crypto = 'opc.tcp://127.0.0.1:{0:d}'.format(port_num2)
+        self.srv_no_crypto.set_endpoint(self.uri_no_crypto)
+        self.srv_no_crypto.start()
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(self):
         # stop the server 
-        cls.srv_no_crypto.stop()
-        cls.srv_crypto.stop()
+        self.srv_no_crypto.stop()
+        self.srv_crypto.stop()
 
     def test_nocrypto(self):
         clt = Client(self.uri_no_crypto)
@@ -56,51 +56,33 @@ class TestCryptoConnect(unittest.TestCase):
         finally:
             clt.disconnect()
 
-    def test_nocrypto_feil(self):
+    def test_nocrypto_fail(self):
         clt = Client(self.uri_no_crypto)
         with self.assertRaises(ua.UaError):
-            clt.set_security_string("Basic256,Sign,examples/certificate-example.der,examples/private-key-example.pem")
+            clt.set_security_string("Basic256Sha256,Sign,examples/certificate-example.der,examples/private-key-example.pem")
 
-    def test_basic256(self):
+    def test_basic256sha256(self):
         clt = Client(self.uri_crypto)
         try:
-            clt.set_security_string("Basic256,Sign,examples/certificate-example.der,examples/private-key-example.pem")
+            clt.set_security_string("Basic256Sha256,Sign,examples/certificate-example.der,examples/private-key-example.pem")
             clt.connect()
             self.assertTrue(clt.get_objects_node().get_children())
         finally:
             clt.disconnect()
 
-    def test_basic256_encrypt(self):
+    def test_basic256sha256_encrypt(self):
         clt = Client(self.uri_crypto)
         try:
-            clt.set_security_string("Basic256,SignAndEncrypt,examples/certificate-example.der,examples/private-key-example.pem")
+            clt.set_security_string("Basic256Sha256,SignAndEncrypt,examples/certificate-example.der,examples/private-key-example.pem")
             clt.connect()
             self.assertTrue(clt.get_objects_node().get_children())
         finally:
             clt.disconnect()
 
-    def test_basic128Rsa15(self):
+    def test_basic256sha56_encrypt_success(self):
         clt = Client(self.uri_crypto)
         try:
-            clt.set_security_string("Basic128Rsa15,Sign,examples/certificate-example.der,examples/private-key-example.pem")
-            clt.connect()
-            self.assertTrue(clt.get_objects_node().get_children())
-        finally:
-            clt.disconnect()
-
-    def test_basic128Rsa15_encrypt(self):
-        clt = Client(self.uri_crypto)
-        try:
-            clt.set_security_string("Basic128Rsa15,SignAndEncrypt,examples/certificate-example.der,examples/private-key-example.pem")
-            clt.connect()
-            self.assertTrue(clt.get_objects_node().get_children())
-        finally:
-            clt.disconnect()
-
-    def test_basic256_encrypt_success(self):
-        clt = Client(self.uri_crypto)
-        try:
-            clt.set_security(security_policies.SecurityPolicyBasic256,
+            clt.set_security(security_policies.SecurityPolicyBasic256Sha256,
                              'examples/certificate-example.der',
                              'examples/private-key-example.pem',
                              None,
@@ -111,11 +93,11 @@ class TestCryptoConnect(unittest.TestCase):
         finally:
             clt.disconnect()
 
-    def test_basic256_encrypt_feil(self):
-        # FIXME: how to make it feil???
+    def test_basic256sha56_encrypt_fail(self):
+        # FIXME: how to make it fail???
         clt = Client(self.uri_crypto)
         with self.assertRaises(ua.UaError):
-            clt.set_security(security_policies.SecurityPolicyBasic256,
+            clt.set_security(security_policies.SecurityPolicyBasic256Sha256,
                              'examples/certificate-example.der',
                              'examples/private-key-example.pem',
                              None,


### PR DESCRIPTION
Basic256 and Basic128Rsa15 use both the sha-1 algorithm.
This is considererd not secure anymore since OPC UA Spec 1.04.
See:
http://opcfoundation.org/UA-Profile/UA/SecurityPolicy%23Basic128Rsa15
http://opcfoundation.org/UA-Profile/UA/SecurityPolicy%23Basic256

This patch removes both of them and adds the security policy
Basic256Sha256.
See:
http://opcfoundation.org/UA-Profile/UA/SecurityPolicy%23Basic256Sha256