### PR TITLE
Delete datachange_callbacks only on copy of dict to delete them from

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -330,7 +330,7 @@ class NodeManagementService(object):
 
     def _delete_node_callbacks(self, nodedata):
         if ua.AttributeIds.Value in nodedata.attributes:
-            for handle, callback in nodedata.attributes[ua.AttributeIds.Value].datachange_callbacks.items():
+            for handle, callback in list(nodedata.attributes[ua.AttributeIds.Value].datachange_callbacks.items()):
                 try:
                     callback(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
                     self._aspace.delete_datachange_callback(handle)


### PR DESCRIPTION
Deleting a node on which any client holds a datachange-notification
subscription, NodeManagementService._delete_node_callbacks fails because
the size of the dictionary it loops over changes. Here, we solve this by
not using the .items() iterator, but making a copy in form of a list
first ….

This is related, but not the same as #659 — their problems was calling from within an existing callback path — here the call legally originates from a separate callpath.