### PR TITLE
fix OSError: [Errno 9] Bad file descriptor

### DIFF
--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -199,7 +199,6 @@ class UASocketClient(object):
                 # some servers send a response here, most do not ... so we ignore
                 future.cancel()
         except OSError as exc:
-            raise
             if exc.errno == errno.EBADF:
                 # Socket is closed, so can't send CloseSecureChannelRequest.
                 self.logger.warning("close_secure_channel() failed: socket already closed")

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -193,12 +193,17 @@ class UASocketClient(object):
         """
         self.logger.info("close_secure_channel")
         request = ua.CloseSecureChannelRequest()
-        future = self._send_request(request, message_type=ua.MessageType.SecureClose)
-        with self._lock:
-            # don't expect any more answers
-            future.cancel()
-
-        # some servers send a response here, most do not ... so we ignore
+        try:
+            future = self._send_request(request, message_type=ua.MessageType.SecureClose)
+            with self._lock:
+                # some servers send a response here, most do not ... so we ignore
+                future.cancel()
+        except OSError as exc:
+            raise
+            if exc.errno == errno.EBADF:
+                pass # Socket is closed, so can't send SecureClose request.
+            else:
+                raise
 
 
 class UaClient(object):

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -201,8 +201,8 @@ class UASocketClient(object):
         except OSError as exc:
             raise
             if exc.errno == errno.EBADF:
+                # Socket is closed, so can't send CloseSecureChannelRequest.
                 self.logger.warning("close_secure_channel() failed: socket already closed")
-                pass # Socket is closed, so can't send SecureClose request.
             else:
                 raise
 

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -201,6 +201,7 @@ class UASocketClient(object):
         except OSError as exc:
             raise
             if exc.errno == errno.EBADF:
+                self.logger.warning("close_secure_channel() failed: socket already closed")
                 pass # Socket is closed, so can't send SecureClose request.
             else:
                 raise


### PR DESCRIPTION
Gracefully handle a client.disconnect() when the underlying socket is already closed.
cfr. https://github.com/FreeOpcUa/python-opcua/issues/741