### PR TITLE
fix client.disconnect() OSError: [Errno 9/107] EBADF/ENOTCONN

### DIFF
--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -148,7 +148,7 @@ class UASocketClient(object):
         try:
             self._socket.socket.shutdown(socket.SHUT_RDWR)
         except OSError as exc:
-            if exc.errno == errno.ENOTCONN:
+            if exc.errno in (errno.ENOTCONN, errno.EBADF):
                 pass # Socket is not connected, so can't send FIN packet.
             else:
                 raise
@@ -199,7 +199,7 @@ class UASocketClient(object):
                 # some servers send a response here, most do not ... so we ignore
                 future.cancel()
         except OSError as exc:
-            if exc.errno == errno.EBADF:
+            if exc.errno in (errno.ENOTCONN, errno.EBADF):
                 # Socket is closed, so can't send CloseSecureChannelRequest.
                 self.logger.warning("close_secure_channel() failed: socket already closed")
             else:

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -147,7 +147,7 @@ class UASocketClient(object):
         self._do_stop = True
         try:
             self._socket.socket.shutdown(socket.SHUT_RDWR)
-        except OSError as exc:
+        except (socket.error, OSError) as exc:
             if exc.errno in (errno.ENOTCONN, errno.EBADF):
                 pass # Socket is not connected, so can't send FIN packet.
             else:
@@ -198,7 +198,7 @@ class UASocketClient(object):
             with self._lock:
                 # some servers send a response here, most do not ... so we ignore
                 future.cancel()
-        except OSError as exc:
+        except (socket.error, OSError) as exc:
             if exc.errno in (errno.ENOTCONN, errno.EBADF):
                 # Socket is closed, so can't send CloseSecureChannelRequest.
                 self.logger.warning("close_secure_channel() failed: socket already closed")


### PR DESCRIPTION
EBADF [errno 9]: socket connection is closed.
ENOTCONN [errno 107]: socket never connected.
cfr. https://www.gnu.org/software/libc/manual/html_node/Receiving-Data.html