### PR TITLE
fix: set SecureConnection state to 'open' on OpenSecureChannelResponse

### DIFF
--- a/opcua/common/connection.py
+++ b/opcua/common/connection.py
@@ -148,6 +148,7 @@ class SecureConnection(object):
         Called on client side when getting secure channel data from server
         """
         self.channel = channel
+        self._open = True
 
     def open(self, params, server):
         """


### PR DESCRIPTION
See https://github.com/FreeOpcUa/python-opcua/issues/745