### PR TITLE
removed deprecated to_binary() from Variant

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -756,9 +756,6 @@ class Variant(FrozenClass):
 
     __repr__ = __str__
 
-    def to_binary(self):
-        from opcua.ua.ua_binary import variant_to_binary
-        return variant_to_binary(self)
 
 
 def _split_list(l, n):


### PR DESCRIPTION
to_binary() was replaced by variant_to_binary as of commit e1067bac

https://github.com/FreeOpcUa/python-opcua/blob/9c115cd4b6a673037e5a1766c2457d1fed1241bf/opcua/ua/uatypes.py#L759-L761

* to_binary() was removed from all classes in uatypes.py except for this one. Probably leftover during refactoring. No leftovers in the source that rely on this method.
* Additionally, it uses an ugly import inside...

Unit-tests also ok.