### PR TITLE
fix: Setting LocalizedText.Text attribute does not update Encoding

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -517,13 +517,23 @@ class LocalizedText(FrozenClass):
 
     def __init__(self, text=None):
         self.Encoding = 0
-        if text is not None and not isinstance(text, str):
-            raise ValueError("A LocalizedText object takes a string as argument, not a {}, {}".format(text, type(text)))
-        self.Text = text
-        if self.Text:
-            self.Encoding |= (1 << 1)
+        self._text = None
+        if text:
+            self.Text = text
         self.Locale = None
         self._freeze = True
+
+    @property
+    def Text(self):
+        return self._text
+
+    @Text.setter
+    def Text(self, text):
+        if not isinstance(text, str):
+            raise ValueError("A LocalizedText object takes a string as argument, not a {}, {}".format(type(text), text))
+        self._text = text
+        if self._text:
+            self.Encoding |= (1 << 1)
 
     def to_string(self):
         # FIXME: use local


### PR DESCRIPTION
See https://github.com/FreeOpcUa/python-opcua/issues/755
This fixes inconsistent Encoding types when performing
y=variant_to_binary(x) -> x2=variant_from_binary(y) on
auto-generated attributes in the standard address space.