### PR TITLE
[#731] Events honor emitting node vs. SourceNode

### DIFF
--- a/opcua/common/event_objects.py
+++ b/opcua/common/event_objects.py
@@ -9,8 +9,8 @@ class BaseEvent(Event):
     """
     BaseEvent: The base type for all events.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        Event.__init__(self)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.NodeId(ua.ObjectIds.Server)):
+        super(BaseEvent, self).__init__(emitting_node=emitting_node)
         self.add_property('EventId', None, ua.VariantType.ByteString)
         self.add_property('EventType', ua.NodeId(ua.ObjectIds.BaseEventType), ua.VariantType.NodeId)
         self.add_property('SourceNode', sourcenode, ua.VariantType.NodeId)
@@ -25,8 +25,8 @@ class AuditEvent(BaseEvent):
     """
     AuditEvent: A base type for events used to track client initiated changes to the server state.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditEventType)
         self.add_property('ActionTimeStamp', None, ua.NodeId(ua.ObjectIds.UtcTime))
         self.add_property('Status', False, ua.VariantType.Boolean)
@@ -38,8 +38,8 @@ class AuditSecurityEvent(AuditEvent):
     """
     AuditSecurityEvent: A base type for events used to track security related changes.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditSecurityEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditSecurityEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditSecurityEventType)
         self.add_property('StatusCodeId', None, ua.VariantType.StatusCode)
 
@@ -47,8 +47,8 @@ class AuditChannelEvent(AuditSecurityEvent):
     """
     AuditChannelEvent: A base type for events used to track related changes to a secure channel.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditChannelEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditChannelEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditChannelEventType)
         self.add_property('SecureChannelId', None, ua.VariantType.String)
 
@@ -56,8 +56,8 @@ class AuditOpenSecureChannelEvent(AuditChannelEvent):
     """
     AuditOpenSecureChannelEvent: An event that is raised when a secure channel is opened.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditOpenSecureChannelEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditOpenSecureChannelEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditOpenSecureChannelEventType)
         self.add_property('ClientCertificate', None, ua.VariantType.ByteString)
         self.add_property('ClientCertificateThumbprint', None, ua.VariantType.String)
@@ -70,8 +70,8 @@ class AuditSessionEvent(AuditSecurityEvent):
     """
     AuditSessionEvent: A base type for events used to track related changes to a session.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditSessionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditSessionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditSessionEventType)
         self.add_property('SessionId', ua.NodeId(ua.ObjectIds.AuditSessionEventType), ua.VariantType.NodeId)
 
@@ -79,8 +79,8 @@ class AuditCreateSessionEvent(AuditSessionEvent):
     """
     AuditCreateSessionEvent: An event that is raised when a session is created.
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCreateSessionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCreateSessionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCreateSessionEventType)
         self.add_property('SecureChannelId', None, ua.VariantType.String)
         self.add_property('ClientCertificate', None, ua.VariantType.ByteString)
@@ -91,8 +91,8 @@ class AuditActivateSessionEvent(AuditSessionEvent):
     """
     AuditActivateSessionEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditActivateSessionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditActivateSessionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditActivateSessionEventType)
         self.add_property('ClientSoftwareCertificates', None, ua.NodeId(ua.ObjectIds.SignedSoftwareCertificate))
         self.add_property('UserIdentityToken', None, ua.NodeId(ua.ObjectIds.UserIdentityToken))
@@ -102,8 +102,8 @@ class AuditCancelEvent(AuditSessionEvent):
     """
     AuditCancelEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCancelEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCancelEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCancelEventType)
         self.add_property('RequestHandle', None, ua.VariantType.UInt32)
 
@@ -111,8 +111,8 @@ class AuditCertificateEvent(AuditSecurityEvent):
     """
     AuditCertificateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateEventType)
         self.add_property('Certificate', None, ua.VariantType.ByteString)
 
@@ -120,8 +120,8 @@ class AuditCertificateDataMismatchEvent(AuditCertificateEvent):
     """
     AuditCertificateDataMismatchEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateDataMismatchEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateDataMismatchEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateDataMismatchEventType)
         self.add_property('InvalidHostname', None, ua.VariantType.String)
         self.add_property('InvalidUri', None, ua.VariantType.String)
@@ -130,56 +130,56 @@ class AuditCertificateExpiredEvent(AuditCertificateEvent):
     """
     AuditCertificateExpiredEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateExpiredEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateExpiredEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateExpiredEventType)
 
 class AuditCertificateInvalidEvent(AuditCertificateEvent):
     """
     AuditCertificateInvalidEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateInvalidEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateInvalidEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateInvalidEventType)
 
 class AuditCertificateUntrustedEvent(AuditCertificateEvent):
     """
     AuditCertificateUntrustedEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateUntrustedEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateUntrustedEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateUntrustedEventType)
 
 class AuditCertificateRevokedEvent(AuditCertificateEvent):
     """
     AuditCertificateRevokedEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateRevokedEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateRevokedEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateRevokedEventType)
 
 class AuditCertificateMismatchEvent(AuditCertificateEvent):
     """
     AuditCertificateMismatchEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditCertificateMismatchEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditCertificateMismatchEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditCertificateMismatchEventType)
 
 class AuditNodeManagementEvent(AuditEvent):
     """
     AuditNodeManagementEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditNodeManagementEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditNodeManagementEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditNodeManagementEventType)
 
 class AuditAddNodesEvent(AuditNodeManagementEvent):
     """
     AuditAddNodesEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditAddNodesEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditAddNodesEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditAddNodesEventType)
         self.add_property('NodesToAdd', None, ua.NodeId(ua.ObjectIds.AddNodesItem))
 
@@ -187,8 +187,8 @@ class AuditDeleteNodesEvent(AuditNodeManagementEvent):
     """
     AuditDeleteNodesEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditDeleteNodesEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditDeleteNodesEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditDeleteNodesEventType)
         self.add_property('NodesToDelete', None, ua.NodeId(ua.ObjectIds.DeleteNodesItem))
 
@@ -196,8 +196,8 @@ class AuditAddReferencesEvent(AuditNodeManagementEvent):
     """
     AuditAddReferencesEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditAddReferencesEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditAddReferencesEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditAddReferencesEventType)
         self.add_property('ReferencesToAdd', None, ua.NodeId(ua.ObjectIds.AddReferencesItem))
 
@@ -205,8 +205,8 @@ class AuditDeleteReferencesEvent(AuditNodeManagementEvent):
     """
     AuditDeleteReferencesEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditDeleteReferencesEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditDeleteReferencesEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditDeleteReferencesEventType)
         self.add_property('ReferencesToDelete', None, ua.NodeId(ua.ObjectIds.DeleteReferencesItem))
 
@@ -214,16 +214,16 @@ class AuditUpdateEvent(AuditEvent):
     """
     AuditUpdateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditUpdateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditUpdateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditUpdateEventType)
 
 class AuditWriteUpdateEvent(AuditUpdateEvent):
     """
     AuditWriteUpdateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditWriteUpdateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditWriteUpdateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditWriteUpdateEventType)
         self.add_property('AttributeId', None, ua.VariantType.UInt32)
         self.add_property('IndexRange', None, ua.NodeId(ua.ObjectIds.NumericRange))
@@ -234,8 +234,8 @@ class AuditHistoryUpdateEvent(AuditUpdateEvent):
     """
     AuditHistoryUpdateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryUpdateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryUpdateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryUpdateEventType)
         self.add_property('ParameterDataTypeId', ua.NodeId(ua.ObjectIds.AuditHistoryUpdateEventType), ua.VariantType.NodeId)
 
@@ -243,8 +243,8 @@ class AuditUpdateMethodEvent(AuditEvent):
     """
     AuditUpdateMethodEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditUpdateMethodEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditUpdateMethodEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditUpdateMethodEventType)
         self.add_property('MethodId', ua.NodeId(ua.ObjectIds.AuditUpdateMethodEventType), ua.VariantType.NodeId)
         self.add_property('InputArguments', None, ua.VariantType.Variant)
@@ -253,32 +253,32 @@ class SystemEvent(BaseEvent):
     """
     SystemEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(SystemEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(SystemEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.SystemEventType)
 
 class DeviceFailureEvent(SystemEvent):
     """
     DeviceFailureEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(DeviceFailureEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(DeviceFailureEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.DeviceFailureEventType)
 
 class BaseModelChangeEvent(BaseEvent):
     """
     BaseModelChangeEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(BaseModelChangeEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(BaseModelChangeEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.BaseModelChangeEventType)
 
 class GeneralModelChangeEvent(BaseModelChangeEvent):
     """
     GeneralModelChangeEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(GeneralModelChangeEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(GeneralModelChangeEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.GeneralModelChangeEventType)
         self.add_property('Changes', None, ua.NodeId(ua.ObjectIds.ModelChangeStructureDataType))
 
@@ -286,16 +286,16 @@ class TransitionEvent(BaseEvent):
     """
     TransitionEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(TransitionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(TransitionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.TransitionEventType)
 
 class AuditUpdateStateEvent(AuditUpdateMethodEvent):
     """
     AuditUpdateStateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditUpdateStateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditUpdateStateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditUpdateStateEventType)
         self.add_property('OldStateId', None, ua.VariantType.Variant)
         self.add_property('NewStateId', None, ua.VariantType.Variant)
@@ -304,8 +304,8 @@ class ProgramTransitionEvent(TransitionEvent):
     """
     ProgramTransitionEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(ProgramTransitionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(ProgramTransitionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.ProgramTransitionEventType)
         self.add_property('IntermediateResult', None, ua.VariantType.Variant)
 
@@ -313,8 +313,8 @@ class SemanticChangeEvent(BaseModelChangeEvent):
     """
     SemanticChangeEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(SemanticChangeEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(SemanticChangeEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.SemanticChangeEventType)
         self.add_property('Changes', None, ua.NodeId(ua.ObjectIds.SemanticChangeStructureDataType))
 
@@ -322,8 +322,8 @@ class AuditUrlMismatchEvent(AuditCreateSessionEvent):
     """
     AuditUrlMismatchEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditUrlMismatchEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditUrlMismatchEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditUrlMismatchEventType)
         self.add_property('EndpointUrl', None, ua.VariantType.String)
 
@@ -331,48 +331,48 @@ class RefreshStartEvent(SystemEvent):
     """
     RefreshStartEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(RefreshStartEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(RefreshStartEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.RefreshStartEventType)
 
 class RefreshEndEvent(SystemEvent):
     """
     RefreshEndEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(RefreshEndEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(RefreshEndEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.RefreshEndEventType)
 
 class RefreshRequiredEvent(SystemEvent):
     """
     RefreshRequiredEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(RefreshRequiredEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(RefreshRequiredEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.RefreshRequiredEventType)
 
 class AuditConditionEvent(AuditUpdateMethodEvent):
     """
     AuditConditionEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionEventType)
 
 class AuditConditionEnableEvent(AuditConditionEvent):
     """
     AuditConditionEnableEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionEnableEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionEnableEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionEnableEventType)
 
 class AuditConditionCommentEvent(AuditConditionEvent):
     """
     AuditConditionCommentEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionCommentEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionCommentEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionCommentEventType)
         self.add_property('ConditionEventId', None, ua.VariantType.ByteString)
         self.add_property('Comment', None, ua.VariantType.LocalizedText)
@@ -381,8 +381,8 @@ class AuditHistoryEventUpdateEvent(AuditHistoryUpdateEvent):
     """
     AuditHistoryEventUpdateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryEventUpdateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryEventUpdateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryEventUpdateEventType)
         self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryEventUpdateEventType), ua.VariantType.NodeId)
         self.add_property('PerformInsertReplace', None, ua.NodeId(ua.ObjectIds.PerformUpdateType))
@@ -394,8 +394,8 @@ class AuditHistoryValueUpdateEvent(AuditHistoryUpdateEvent):
     """
     AuditHistoryValueUpdateEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryValueUpdateEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryValueUpdateEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryValueUpdateEventType)
         self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryValueUpdateEventType), ua.VariantType.NodeId)
         self.add_property('PerformInsertReplace', None, ua.NodeId(ua.ObjectIds.PerformUpdateType))
@@ -406,8 +406,8 @@ class AuditHistoryDeleteEvent(AuditHistoryUpdateEvent):
     """
     AuditHistoryDeleteEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryDeleteEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryDeleteEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryDeleteEventType)
         self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryDeleteEventType), ua.VariantType.NodeId)
 
@@ -415,8 +415,8 @@ class AuditHistoryRawModifyDeleteEvent(AuditHistoryDeleteEvent):
     """
     AuditHistoryRawModifyDeleteEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryRawModifyDeleteEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryRawModifyDeleteEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryRawModifyDeleteEventType)
         self.add_property('IsDeleteModified', None, ua.VariantType.Boolean)
         self.add_property('StartTime', None, ua.VariantType.DateTime)
@@ -427,8 +427,8 @@ class AuditHistoryAtTimeDeleteEvent(AuditHistoryDeleteEvent):
     """
     AuditHistoryAtTimeDeleteEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryAtTimeDeleteEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryAtTimeDeleteEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryAtTimeDeleteEventType)
         self.add_property('ReqTimes', None, ua.NodeId(ua.ObjectIds.UtcTime))
         self.add_property('OldValues', None, ua.NodeId(ua.ObjectIds.DataValue))
@@ -437,8 +437,8 @@ class AuditHistoryEventDeleteEvent(AuditHistoryDeleteEvent):
     """
     AuditHistoryEventDeleteEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditHistoryEventDeleteEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditHistoryEventDeleteEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryEventDeleteEventType)
         self.add_property('EventIds', None, ua.VariantType.ByteString)
         self.add_property('OldValues', None, ua.NodeId(ua.ObjectIds.HistoryEventFieldList))
@@ -447,24 +447,24 @@ class EventQueueOverflowEvent(BaseEvent):
     """
     EventQueueOverflowEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(EventQueueOverflowEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(EventQueueOverflowEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.EventQueueOverflowEventType)
 
 class ProgramTransitionAuditEvent(AuditUpdateStateEvent):
     """
     ProgramTransitionAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(ProgramTransitionAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(ProgramTransitionAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.ProgramTransitionAuditEventType)
 
 class AuditConditionRespondEvent(AuditConditionEvent):
     """
     AuditConditionRespondEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionRespondEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionRespondEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionRespondEventType)
         self.add_property('SelectedResponse', None, ua.VariantType.Int32)
 
@@ -472,8 +472,8 @@ class AuditConditionAcknowledgeEvent(AuditConditionEvent):
     """
     AuditConditionAcknowledgeEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionAcknowledgeEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionAcknowledgeEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionAcknowledgeEventType)
         self.add_property('ConditionEventId', None, ua.VariantType.ByteString)
         self.add_property('Comment', None, ua.VariantType.LocalizedText)
@@ -482,8 +482,8 @@ class AuditConditionConfirmEvent(AuditConditionEvent):
     """
     AuditConditionConfirmEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionConfirmEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionConfirmEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionConfirmEventType)
         self.add_property('ConditionEventId', None, ua.VariantType.ByteString)
         self.add_property('Comment', None, ua.VariantType.LocalizedText)
@@ -492,8 +492,8 @@ class AuditConditionShelvingEvent(AuditConditionEvent):
     """
     AuditConditionShelvingEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionShelvingEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionShelvingEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionShelvingEventType)
         self.add_property('ShelvingTime', None, ua.VariantType.DateTime)
 
@@ -501,8 +501,8 @@ class ProgressEvent(BaseEvent):
     """
     ProgressEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(ProgressEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(ProgressEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.ProgressEventType)
         self.add_property('Context', None, ua.VariantType.Variant)
         self.add_property('Progress', None, ua.VariantType.UInt16)
@@ -511,8 +511,8 @@ class SystemStatusChangeEvent(SystemEvent):
     """
     SystemStatusChangeEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(SystemStatusChangeEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(SystemStatusChangeEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.SystemStatusChangeEventType)
         self.add_property('SystemState', None, ua.NodeId(ua.ObjectIds.ServerState))
 
@@ -520,8 +520,8 @@ class AuditProgramTransitionEvent(AuditUpdateStateEvent):
     """
     AuditProgramTransitionEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditProgramTransitionEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditProgramTransitionEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditProgramTransitionEventType)
         self.add_property('TransitionNumber', None, ua.VariantType.UInt32)
 
@@ -529,16 +529,16 @@ class TrustListUpdatedAuditEvent(AuditUpdateMethodEvent):
     """
     TrustListUpdatedAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(TrustListUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(TrustListUpdatedAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.TrustListUpdatedAuditEventType)
 
 class CertificateUpdatedAuditEvent(AuditUpdateMethodEvent):
     """
     CertificateUpdatedAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(CertificateUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(CertificateUpdatedAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType)
         self.add_property('CertificateGroup', ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType), ua.VariantType.NodeId)
         self.add_property('CertificateType', ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType), ua.VariantType.NodeId)
@@ -547,16 +547,16 @@ class AuditConditionResetEvent(AuditConditionEvent):
     """
     AuditConditionResetEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionResetEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionResetEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionResetEventType)
 
 class PubSubStatusEvent(SystemEvent):
     """
     PubSubStatusEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(PubSubStatusEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(PubSubStatusEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.PubSubStatusEventType)
         self.add_property('ConnectionId', ua.NodeId(ua.ObjectIds.PubSubStatusEventType), ua.VariantType.NodeId)
         self.add_property('GroupId', ua.NodeId(ua.ObjectIds.PubSubStatusEventType), ua.VariantType.NodeId)
@@ -566,8 +566,8 @@ class PubSubTransportLimitsExceedEvent(PubSubStatusEvent):
     """
     PubSubTransportLimitsExceedEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(PubSubTransportLimitsExceedEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(PubSubTransportLimitsExceedEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.PubSubTransportLimitsExceedEventType)
         self.add_property('Actual', None, ua.VariantType.UInt32)
         self.add_property('Maximum', None, ua.VariantType.UInt32)
@@ -576,8 +576,8 @@ class PubSubCommunicationFailureEvent(PubSubStatusEvent):
     """
     PubSubCommunicationFailureEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(PubSubCommunicationFailureEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(PubSubCommunicationFailureEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.PubSubCommunicationFailureEventType)
         self.add_property('Error', None, ua.VariantType.StatusCode)
 
@@ -585,40 +585,40 @@ class AuditConditionSuppressEvent(AuditConditionEvent):
     """
     AuditConditionSuppressEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionSuppressEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionSuppressEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionSuppressEventType)
 
 class AuditConditionSilenceEvent(AuditConditionEvent):
     """
     AuditConditionSilenceEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionSilenceEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionSilenceEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionSilenceEventType)
 
 class AuditConditionOutOfServiceEvent(AuditConditionEvent):
     """
     AuditConditionOutOfServiceEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(AuditConditionOutOfServiceEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(AuditConditionOutOfServiceEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditConditionOutOfServiceEventType)
 
 class RoleMappingRuleChangedAuditEvent(AuditUpdateMethodEvent):
     """
     RoleMappingRuleChangedAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(RoleMappingRuleChangedAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(RoleMappingRuleChangedAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.RoleMappingRuleChangedAuditEventType)
 
 class KeyCredentialAuditEvent(AuditUpdateMethodEvent):
     """
     KeyCredentialAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(KeyCredentialAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(KeyCredentialAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.KeyCredentialAuditEventType)
         self.add_property('ResourceUri', None, ua.VariantType.String)
 
@@ -626,16 +626,16 @@ class KeyCredentialUpdatedAuditEvent(KeyCredentialAuditEvent):
     """
     KeyCredentialUpdatedAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(KeyCredentialUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(KeyCredentialUpdatedAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.KeyCredentialUpdatedAuditEventType)
 
 class KeyCredentialDeletedAuditEvent(KeyCredentialAuditEvent):
     """
     KeyCredentialDeletedAuditEvent:
     """
-    def __init__(self, sourcenode=None, message=None, severity=1):
-        super(KeyCredentialDeletedAuditEvent, self).__init__(sourcenode, message, severity)
+    def __init__(self, sourcenode=None, message=None, severity=1, emitting_node=ua.ObjectIds.Server):
+        super(KeyCredentialDeletedAuditEvent, self).__init__(sourcenode, message, severity, emitting_node=emitting_node)
         self.EventType = ua.NodeId(ua.ObjectIds.KeyCredentialDeletedAuditEventType)
 
 

--- a/opcua/common/event_objects.py
+++ b/opcua/common/event_objects.py
@@ -89,7 +89,7 @@ class AuditCreateSessionEvent(AuditSessionEvent):
 
 class AuditActivateSessionEvent(AuditSessionEvent):
     """
-    AuditActivateSessionEvent: 
+    AuditActivateSessionEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditActivateSessionEvent, self).__init__(sourcenode, message, severity)
@@ -100,7 +100,7 @@ class AuditActivateSessionEvent(AuditSessionEvent):
 
 class AuditCancelEvent(AuditSessionEvent):
     """
-    AuditCancelEvent: 
+    AuditCancelEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCancelEvent, self).__init__(sourcenode, message, severity)
@@ -109,7 +109,7 @@ class AuditCancelEvent(AuditSessionEvent):
 
 class AuditCertificateEvent(AuditSecurityEvent):
     """
-    AuditCertificateEvent: 
+    AuditCertificateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateEvent, self).__init__(sourcenode, message, severity)
@@ -118,7 +118,7 @@ class AuditCertificateEvent(AuditSecurityEvent):
 
 class AuditCertificateDataMismatchEvent(AuditCertificateEvent):
     """
-    AuditCertificateDataMismatchEvent: 
+    AuditCertificateDataMismatchEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateDataMismatchEvent, self).__init__(sourcenode, message, severity)
@@ -128,7 +128,7 @@ class AuditCertificateDataMismatchEvent(AuditCertificateEvent):
 
 class AuditCertificateExpiredEvent(AuditCertificateEvent):
     """
-    AuditCertificateExpiredEvent: 
+    AuditCertificateExpiredEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateExpiredEvent, self).__init__(sourcenode, message, severity)
@@ -136,7 +136,7 @@ class AuditCertificateExpiredEvent(AuditCertificateEvent):
 
 class AuditCertificateInvalidEvent(AuditCertificateEvent):
     """
-    AuditCertificateInvalidEvent: 
+    AuditCertificateInvalidEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateInvalidEvent, self).__init__(sourcenode, message, severity)
@@ -144,7 +144,7 @@ class AuditCertificateInvalidEvent(AuditCertificateEvent):
 
 class AuditCertificateUntrustedEvent(AuditCertificateEvent):
     """
-    AuditCertificateUntrustedEvent: 
+    AuditCertificateUntrustedEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateUntrustedEvent, self).__init__(sourcenode, message, severity)
@@ -152,7 +152,7 @@ class AuditCertificateUntrustedEvent(AuditCertificateEvent):
 
 class AuditCertificateRevokedEvent(AuditCertificateEvent):
     """
-    AuditCertificateRevokedEvent: 
+    AuditCertificateRevokedEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateRevokedEvent, self).__init__(sourcenode, message, severity)
@@ -160,7 +160,7 @@ class AuditCertificateRevokedEvent(AuditCertificateEvent):
 
 class AuditCertificateMismatchEvent(AuditCertificateEvent):
     """
-    AuditCertificateMismatchEvent: 
+    AuditCertificateMismatchEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditCertificateMismatchEvent, self).__init__(sourcenode, message, severity)
@@ -168,7 +168,7 @@ class AuditCertificateMismatchEvent(AuditCertificateEvent):
 
 class AuditNodeManagementEvent(AuditEvent):
     """
-    AuditNodeManagementEvent: 
+    AuditNodeManagementEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditNodeManagementEvent, self).__init__(sourcenode, message, severity)
@@ -176,7 +176,7 @@ class AuditNodeManagementEvent(AuditEvent):
 
 class AuditAddNodesEvent(AuditNodeManagementEvent):
     """
-    AuditAddNodesEvent: 
+    AuditAddNodesEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditAddNodesEvent, self).__init__(sourcenode, message, severity)
@@ -185,7 +185,7 @@ class AuditAddNodesEvent(AuditNodeManagementEvent):
 
 class AuditDeleteNodesEvent(AuditNodeManagementEvent):
     """
-    AuditDeleteNodesEvent: 
+    AuditDeleteNodesEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditDeleteNodesEvent, self).__init__(sourcenode, message, severity)
@@ -194,7 +194,7 @@ class AuditDeleteNodesEvent(AuditNodeManagementEvent):
 
 class AuditAddReferencesEvent(AuditNodeManagementEvent):
     """
-    AuditAddReferencesEvent: 
+    AuditAddReferencesEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditAddReferencesEvent, self).__init__(sourcenode, message, severity)
@@ -203,7 +203,7 @@ class AuditAddReferencesEvent(AuditNodeManagementEvent):
 
 class AuditDeleteReferencesEvent(AuditNodeManagementEvent):
     """
-    AuditDeleteReferencesEvent: 
+    AuditDeleteReferencesEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditDeleteReferencesEvent, self).__init__(sourcenode, message, severity)
@@ -212,7 +212,7 @@ class AuditDeleteReferencesEvent(AuditNodeManagementEvent):
 
 class AuditUpdateEvent(AuditEvent):
     """
-    AuditUpdateEvent: 
+    AuditUpdateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditUpdateEvent, self).__init__(sourcenode, message, severity)
@@ -220,7 +220,7 @@ class AuditUpdateEvent(AuditEvent):
 
 class AuditWriteUpdateEvent(AuditUpdateEvent):
     """
-    AuditWriteUpdateEvent: 
+    AuditWriteUpdateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditWriteUpdateEvent, self).__init__(sourcenode, message, severity)
@@ -232,7 +232,7 @@ class AuditWriteUpdateEvent(AuditUpdateEvent):
 
 class AuditHistoryUpdateEvent(AuditUpdateEvent):
     """
-    AuditHistoryUpdateEvent: 
+    AuditHistoryUpdateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryUpdateEvent, self).__init__(sourcenode, message, severity)
@@ -241,7 +241,7 @@ class AuditHistoryUpdateEvent(AuditUpdateEvent):
 
 class AuditUpdateMethodEvent(AuditEvent):
     """
-    AuditUpdateMethodEvent: 
+    AuditUpdateMethodEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditUpdateMethodEvent, self).__init__(sourcenode, message, severity)
@@ -251,7 +251,7 @@ class AuditUpdateMethodEvent(AuditEvent):
 
 class SystemEvent(BaseEvent):
     """
-    SystemEvent: 
+    SystemEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(SystemEvent, self).__init__(sourcenode, message, severity)
@@ -259,7 +259,7 @@ class SystemEvent(BaseEvent):
 
 class DeviceFailureEvent(SystemEvent):
     """
-    DeviceFailureEvent: 
+    DeviceFailureEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(DeviceFailureEvent, self).__init__(sourcenode, message, severity)
@@ -267,7 +267,7 @@ class DeviceFailureEvent(SystemEvent):
 
 class BaseModelChangeEvent(BaseEvent):
     """
-    BaseModelChangeEvent: 
+    BaseModelChangeEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(BaseModelChangeEvent, self).__init__(sourcenode, message, severity)
@@ -275,7 +275,7 @@ class BaseModelChangeEvent(BaseEvent):
 
 class GeneralModelChangeEvent(BaseModelChangeEvent):
     """
-    GeneralModelChangeEvent: 
+    GeneralModelChangeEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(GeneralModelChangeEvent, self).__init__(sourcenode, message, severity)
@@ -284,7 +284,7 @@ class GeneralModelChangeEvent(BaseModelChangeEvent):
 
 class TransitionEvent(BaseEvent):
     """
-    TransitionEvent: 
+    TransitionEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(TransitionEvent, self).__init__(sourcenode, message, severity)
@@ -292,7 +292,7 @@ class TransitionEvent(BaseEvent):
 
 class AuditUpdateStateEvent(AuditUpdateMethodEvent):
     """
-    AuditUpdateStateEvent: 
+    AuditUpdateStateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditUpdateStateEvent, self).__init__(sourcenode, message, severity)
@@ -302,7 +302,7 @@ class AuditUpdateStateEvent(AuditUpdateMethodEvent):
 
 class ProgramTransitionEvent(TransitionEvent):
     """
-    ProgramTransitionEvent: 
+    ProgramTransitionEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(ProgramTransitionEvent, self).__init__(sourcenode, message, severity)
@@ -311,7 +311,7 @@ class ProgramTransitionEvent(TransitionEvent):
 
 class SemanticChangeEvent(BaseModelChangeEvent):
     """
-    SemanticChangeEvent: 
+    SemanticChangeEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(SemanticChangeEvent, self).__init__(sourcenode, message, severity)
@@ -320,7 +320,7 @@ class SemanticChangeEvent(BaseModelChangeEvent):
 
 class AuditUrlMismatchEvent(AuditCreateSessionEvent):
     """
-    AuditUrlMismatchEvent: 
+    AuditUrlMismatchEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditUrlMismatchEvent, self).__init__(sourcenode, message, severity)
@@ -329,7 +329,7 @@ class AuditUrlMismatchEvent(AuditCreateSessionEvent):
 
 class RefreshStartEvent(SystemEvent):
     """
-    RefreshStartEvent: 
+    RefreshStartEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(RefreshStartEvent, self).__init__(sourcenode, message, severity)
@@ -337,7 +337,7 @@ class RefreshStartEvent(SystemEvent):
 
 class RefreshEndEvent(SystemEvent):
     """
-    RefreshEndEvent: 
+    RefreshEndEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(RefreshEndEvent, self).__init__(sourcenode, message, severity)
@@ -345,7 +345,7 @@ class RefreshEndEvent(SystemEvent):
 
 class RefreshRequiredEvent(SystemEvent):
     """
-    RefreshRequiredEvent: 
+    RefreshRequiredEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(RefreshRequiredEvent, self).__init__(sourcenode, message, severity)
@@ -353,7 +353,7 @@ class RefreshRequiredEvent(SystemEvent):
 
 class AuditConditionEvent(AuditUpdateMethodEvent):
     """
-    AuditConditionEvent: 
+    AuditConditionEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionEvent, self).__init__(sourcenode, message, severity)
@@ -361,7 +361,7 @@ class AuditConditionEvent(AuditUpdateMethodEvent):
 
 class AuditConditionEnableEvent(AuditConditionEvent):
     """
-    AuditConditionEnableEvent: 
+    AuditConditionEnableEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionEnableEvent, self).__init__(sourcenode, message, severity)
@@ -369,7 +369,7 @@ class AuditConditionEnableEvent(AuditConditionEvent):
 
 class AuditConditionCommentEvent(AuditConditionEvent):
     """
-    AuditConditionCommentEvent: 
+    AuditConditionCommentEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionCommentEvent, self).__init__(sourcenode, message, severity)
@@ -379,7 +379,7 @@ class AuditConditionCommentEvent(AuditConditionEvent):
 
 class AuditHistoryEventUpdateEvent(AuditHistoryUpdateEvent):
     """
-    AuditHistoryEventUpdateEvent: 
+    AuditHistoryEventUpdateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryEventUpdateEvent, self).__init__(sourcenode, message, severity)
@@ -392,7 +392,7 @@ class AuditHistoryEventUpdateEvent(AuditHistoryUpdateEvent):
 
 class AuditHistoryValueUpdateEvent(AuditHistoryUpdateEvent):
     """
-    AuditHistoryValueUpdateEvent: 
+    AuditHistoryValueUpdateEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryValueUpdateEvent, self).__init__(sourcenode, message, severity)
@@ -404,7 +404,7 @@ class AuditHistoryValueUpdateEvent(AuditHistoryUpdateEvent):
 
 class AuditHistoryDeleteEvent(AuditHistoryUpdateEvent):
     """
-    AuditHistoryDeleteEvent: 
+    AuditHistoryDeleteEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryDeleteEvent, self).__init__(sourcenode, message, severity)
@@ -413,7 +413,7 @@ class AuditHistoryDeleteEvent(AuditHistoryUpdateEvent):
 
 class AuditHistoryRawModifyDeleteEvent(AuditHistoryDeleteEvent):
     """
-    AuditHistoryRawModifyDeleteEvent: 
+    AuditHistoryRawModifyDeleteEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryRawModifyDeleteEvent, self).__init__(sourcenode, message, severity)
@@ -425,7 +425,7 @@ class AuditHistoryRawModifyDeleteEvent(AuditHistoryDeleteEvent):
 
 class AuditHistoryAtTimeDeleteEvent(AuditHistoryDeleteEvent):
     """
-    AuditHistoryAtTimeDeleteEvent: 
+    AuditHistoryAtTimeDeleteEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryAtTimeDeleteEvent, self).__init__(sourcenode, message, severity)
@@ -435,7 +435,7 @@ class AuditHistoryAtTimeDeleteEvent(AuditHistoryDeleteEvent):
 
 class AuditHistoryEventDeleteEvent(AuditHistoryDeleteEvent):
     """
-    AuditHistoryEventDeleteEvent: 
+    AuditHistoryEventDeleteEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditHistoryEventDeleteEvent, self).__init__(sourcenode, message, severity)
@@ -445,7 +445,7 @@ class AuditHistoryEventDeleteEvent(AuditHistoryDeleteEvent):
 
 class EventQueueOverflowEvent(BaseEvent):
     """
-    EventQueueOverflowEvent: 
+    EventQueueOverflowEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(EventQueueOverflowEvent, self).__init__(sourcenode, message, severity)
@@ -453,7 +453,7 @@ class EventQueueOverflowEvent(BaseEvent):
 
 class ProgramTransitionAuditEvent(AuditUpdateStateEvent):
     """
-    ProgramTransitionAuditEvent: 
+    ProgramTransitionAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(ProgramTransitionAuditEvent, self).__init__(sourcenode, message, severity)
@@ -461,7 +461,7 @@ class ProgramTransitionAuditEvent(AuditUpdateStateEvent):
 
 class AuditConditionRespondEvent(AuditConditionEvent):
     """
-    AuditConditionRespondEvent: 
+    AuditConditionRespondEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionRespondEvent, self).__init__(sourcenode, message, severity)
@@ -470,7 +470,7 @@ class AuditConditionRespondEvent(AuditConditionEvent):
 
 class AuditConditionAcknowledgeEvent(AuditConditionEvent):
     """
-    AuditConditionAcknowledgeEvent: 
+    AuditConditionAcknowledgeEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionAcknowledgeEvent, self).__init__(sourcenode, message, severity)
@@ -480,7 +480,7 @@ class AuditConditionAcknowledgeEvent(AuditConditionEvent):
 
 class AuditConditionConfirmEvent(AuditConditionEvent):
     """
-    AuditConditionConfirmEvent: 
+    AuditConditionConfirmEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionConfirmEvent, self).__init__(sourcenode, message, severity)
@@ -490,7 +490,7 @@ class AuditConditionConfirmEvent(AuditConditionEvent):
 
 class AuditConditionShelvingEvent(AuditConditionEvent):
     """
-    AuditConditionShelvingEvent: 
+    AuditConditionShelvingEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionShelvingEvent, self).__init__(sourcenode, message, severity)
@@ -499,7 +499,7 @@ class AuditConditionShelvingEvent(AuditConditionEvent):
 
 class ProgressEvent(BaseEvent):
     """
-    ProgressEvent: 
+    ProgressEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(ProgressEvent, self).__init__(sourcenode, message, severity)
@@ -509,7 +509,7 @@ class ProgressEvent(BaseEvent):
 
 class SystemStatusChangeEvent(SystemEvent):
     """
-    SystemStatusChangeEvent: 
+    SystemStatusChangeEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(SystemStatusChangeEvent, self).__init__(sourcenode, message, severity)
@@ -518,7 +518,7 @@ class SystemStatusChangeEvent(SystemEvent):
 
 class AuditProgramTransitionEvent(AuditUpdateStateEvent):
     """
-    AuditProgramTransitionEvent: 
+    AuditProgramTransitionEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditProgramTransitionEvent, self).__init__(sourcenode, message, severity)
@@ -527,7 +527,7 @@ class AuditProgramTransitionEvent(AuditUpdateStateEvent):
 
 class TrustListUpdatedAuditEvent(AuditUpdateMethodEvent):
     """
-    TrustListUpdatedAuditEvent: 
+    TrustListUpdatedAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(TrustListUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
@@ -535,7 +535,7 @@ class TrustListUpdatedAuditEvent(AuditUpdateMethodEvent):
 
 class CertificateUpdatedAuditEvent(AuditUpdateMethodEvent):
     """
-    CertificateUpdatedAuditEvent: 
+    CertificateUpdatedAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(CertificateUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
@@ -545,7 +545,7 @@ class CertificateUpdatedAuditEvent(AuditUpdateMethodEvent):
 
 class AuditConditionResetEvent(AuditConditionEvent):
     """
-    AuditConditionResetEvent: 
+    AuditConditionResetEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionResetEvent, self).__init__(sourcenode, message, severity)
@@ -553,7 +553,7 @@ class AuditConditionResetEvent(AuditConditionEvent):
 
 class PubSubStatusEvent(SystemEvent):
     """
-    PubSubStatusEvent: 
+    PubSubStatusEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(PubSubStatusEvent, self).__init__(sourcenode, message, severity)
@@ -564,7 +564,7 @@ class PubSubStatusEvent(SystemEvent):
 
 class PubSubTransportLimitsExceedEvent(PubSubStatusEvent):
     """
-    PubSubTransportLimitsExceedEvent: 
+    PubSubTransportLimitsExceedEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(PubSubTransportLimitsExceedEvent, self).__init__(sourcenode, message, severity)
@@ -574,7 +574,7 @@ class PubSubTransportLimitsExceedEvent(PubSubStatusEvent):
 
 class PubSubCommunicationFailureEvent(PubSubStatusEvent):
     """
-    PubSubCommunicationFailureEvent: 
+    PubSubCommunicationFailureEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(PubSubCommunicationFailureEvent, self).__init__(sourcenode, message, severity)
@@ -583,7 +583,7 @@ class PubSubCommunicationFailureEvent(PubSubStatusEvent):
 
 class AuditConditionSuppressEvent(AuditConditionEvent):
     """
-    AuditConditionSuppressEvent: 
+    AuditConditionSuppressEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionSuppressEvent, self).__init__(sourcenode, message, severity)
@@ -591,7 +591,7 @@ class AuditConditionSuppressEvent(AuditConditionEvent):
 
 class AuditConditionSilenceEvent(AuditConditionEvent):
     """
-    AuditConditionSilenceEvent: 
+    AuditConditionSilenceEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionSilenceEvent, self).__init__(sourcenode, message, severity)
@@ -599,7 +599,7 @@ class AuditConditionSilenceEvent(AuditConditionEvent):
 
 class AuditConditionOutOfServiceEvent(AuditConditionEvent):
     """
-    AuditConditionOutOfServiceEvent: 
+    AuditConditionOutOfServiceEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(AuditConditionOutOfServiceEvent, self).__init__(sourcenode, message, severity)
@@ -607,7 +607,7 @@ class AuditConditionOutOfServiceEvent(AuditConditionEvent):
 
 class RoleMappingRuleChangedAuditEvent(AuditUpdateMethodEvent):
     """
-    RoleMappingRuleChangedAuditEvent: 
+    RoleMappingRuleChangedAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(RoleMappingRuleChangedAuditEvent, self).__init__(sourcenode, message, severity)
@@ -615,7 +615,7 @@ class RoleMappingRuleChangedAuditEvent(AuditUpdateMethodEvent):
 
 class KeyCredentialAuditEvent(AuditUpdateMethodEvent):
     """
-    KeyCredentialAuditEvent: 
+    KeyCredentialAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(KeyCredentialAuditEvent, self).__init__(sourcenode, message, severity)
@@ -624,7 +624,7 @@ class KeyCredentialAuditEvent(AuditUpdateMethodEvent):
 
 class KeyCredentialUpdatedAuditEvent(KeyCredentialAuditEvent):
     """
-    KeyCredentialUpdatedAuditEvent: 
+    KeyCredentialUpdatedAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(KeyCredentialUpdatedAuditEvent, self).__init__(sourcenode, message, severity)
@@ -632,7 +632,7 @@ class KeyCredentialUpdatedAuditEvent(KeyCredentialAuditEvent):
 
 class KeyCredentialDeletedAuditEvent(KeyCredentialAuditEvent):
     """
-    KeyCredentialDeletedAuditEvent: 
+    KeyCredentialDeletedAuditEvent:
     """
     def __init__(self, sourcenode=None, message=None, severity=1):
         super(KeyCredentialDeletedAuditEvent, self).__init__(sourcenode, message, severity)

--- a/opcua/common/events.py
+++ b/opcua/common/events.py
@@ -63,7 +63,7 @@ class Event(object):
     def to_event_fields_using_subscription_fields(self, select_clauses):
         """
         Using a new select_clauses and the original select_clauses
-        used during subscription, return a field list 
+        used during subscription, return a field list
         """
         fields = []
         for sattr in select_clauses:
@@ -134,7 +134,7 @@ def select_clauses_from_evtype(evtypes):
 def where_clause_from_evtype(evtypes):
     cf = ua.ContentFilter()
     el = ua.ContentFilterElement()
-    
+
     # operands can be ElementOperand, LiteralOperand, AttributeOperand, SimpleAttribute
     # Create a clause where the generate event type property EventType
     # must be a subtype of events in evtypes argument

--- a/opcua/common/events.py
+++ b/opcua/common/events.py
@@ -19,17 +19,18 @@ class Event(object):
     add properties using the add_property method!!!
     """
 
-    def __init__(self):
+    def __init__(self, emitting_node=ua.ObjectIds.Server):
         self.server_handle = None
         self.select_clauses = None
         self.event_fields = None
         self.data_types = {}
+        self.emitting_node = emitting_node
         # save current attributes
         self.internal_properties = list(self.__dict__.keys())[:] + ["internal_properties"]
 
     def __str__(self):
         return "{0}({1})".format(
-            self.__class__.__name__, 
+            self.__class__.__name__,
             [str(k) + ":" + str(v) for k, v in self.__dict__.items() if k not in self.internal_properties])
     __repr__ = __str__
 

--- a/opcua/server/internal_subscription.py
+++ b/opcua/server/internal_subscription.py
@@ -218,13 +218,13 @@ class MonitoredItemService(object):
 
     def trigger_event(self, event):
         with self._lock:
-            if event.SourceNode not in self._monitored_events:
+            if event.emitting_node not in self._monitored_events:
                 self.logger.debug("%s has no subscription for events %s from node: %s",
-                                  self, event, event.SourceNode)
+                                  self, event, event.emitting_node)
                 return False
             self.logger.debug("%s has subscription for events %s from node: %s",
-                              self, event, event.SourceNode)
-            mids = self._monitored_events[event.SourceNode]
+                              self, event, event.emitting_node)
+            mids = self._monitored_events[event.emitting_node]
             for mid in mids:
                 self._trigger_event(event, mid)
 

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -417,14 +417,14 @@ class Server(object):
         uries = self.get_namespace_array()
         return uries.index(uri)
 
-    def get_event_generator(self, etype=None, source=ua.ObjectIds.Server):
+    def get_event_generator(self, etype=None, emitting_node=ua.ObjectIds.Server):
         """
         Returns an event object using an event type from address space.
         Use this object to fire events
         """
         if not etype:
             etype = BaseEvent()
-        return EventGenerator(self.iserver.isession, etype, source)
+        return EventGenerator(self.iserver.isession, etype, emitting_node=emitting_node)
 
     def create_custom_data_type(self, idx, name, basetype=ua.ObjectIds.BaseDataType, properties=None):
         if properties is None:

--- a/tests/tests_subscriptions.py
+++ b/tests/tests_subscriptions.py
@@ -373,11 +373,13 @@ class SubscriptionTests(object):
     def test_events_MyObject(self):
         objects = self.srv.get_objects_node()
         o = objects.add_object(3, 'MyObject')
-        evgen = self.srv.get_event_generator(source=o)
+        evgen = self.srv.get_event_generator()
+        evgen.event.SourceNode=o.nodeid
+        evgen.event.SourceName=o.get_browse_name().Name
 
         myhandler = MySubHandler()
         sub = self.opc.create_subscription(100, myhandler)
-        handle = sub.subscribe_events(o)
+        handle = sub.subscribe_events()
 
         tid = datetime.utcnow()
         msg = "this is my msg "
@@ -399,7 +401,7 @@ class SubscriptionTests(object):
     def test_events_wrong_source(self):
         objects = self.srv.get_objects_node()
         o = objects.add_object(3, 'MyObject')
-        evgen = self.srv.get_event_generator(source=o)
+        evgen = self.srv.get_event_generator(emitting_node=o)
 
         myhandler = MySubHandler()
         sub = self.opc.create_subscription(100, myhandler)
@@ -422,7 +424,7 @@ class SubscriptionTests(object):
 
         myhandler = MySubHandler()
         sub = self.opc.create_subscription(100, myhandler)
-        handle = sub.subscribe_events(evtypes=etype)
+        handle = sub.subscribe_events(sourcenode=ua.ObjectIds.Server, evtypes=etype)
 
         propertynum = 2
         propertystring = "This is my test"
@@ -453,16 +455,18 @@ class SubscriptionTests(object):
         objects = self.srv.get_objects_node()
         o = objects.add_object(3, 'MyObject')
         etype = self.srv.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('PropertyNum', ua.VariantType.Float), ('PropertyString', ua.VariantType.String)])
-        evgen = self.srv.get_event_generator(etype, o)
+        evgen = self.srv.get_event_generator(etype, emitting_node=o)
+        evgen.event.SourceNode = o.nodeid
 
         myhandler = MySubHandler()
         sub = self.opc.create_subscription(100, myhandler)
-        handle = sub.subscribe_events(o, etype)
+        handle = sub.subscribe_events(sourcenode=o, evtypes=etype)
 
         propertynum = 2
         propertystring = "This is my test"
         evgen.event.PropertyNum = propertynum
         evgen.event.PropertyString = propertystring
+        evgen.event.SourceNode = o.nodeid
         tid = datetime.utcnow()
         msg = "this is my msg "
         evgen.trigger(tid, msg)

--- a/tests/tests_subscriptions.py
+++ b/tests/tests_subscriptions.py
@@ -505,7 +505,7 @@ class SubscriptionTests(object):
         propertystring2 = "This is my test 2"
         evgen2.event.PropertyNum = propertynum2
         evgen2.event.PropertyString = propertystring2
-        
+
         for i in range(3):
             evgen1.trigger()
             evgen2.trigger()
@@ -563,7 +563,7 @@ class SubscriptionTests(object):
         propertystring3 = "This is my test 3"
         evgen3.event.PropertyNum3 = propertynum3
         evgen3.event.PropertyString = propertystring2
-        
+
         for i in range(3):
             evgen1.trigger()
             evgen2.trigger()


### PR DESCRIPTION
In #731 we discussed that the emitting node of an event may be different from the SourceNode this event loosely describes as its original source.

This PR tries to implement the correct behavior. Unfortunately, this led me to perform some API changes to (hopefully) make event-handling seem more straightforward to the user.

One thing i found ugly is that i had to change so many tests — especially the utility functions of the collision one i wasn’t sure if this is really correctly checking what we mean. Can you please have a good look over these?

Also, if there‘s any interest in in, should I add an example for generating AuditEvents?