### PR TITLE
Surface send_hello server errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ examples/history.db
 /.project
 /.pydevproject
 /.settings/
+
+# DS_Store
+.DS_Store

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -212,10 +212,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             endpoints = self.get_endpoints()
             self.close_secure_channel()
@@ -230,10 +226,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()  # spec says it should not be necessary to open channel
             servers = self.find_servers()
             self.close_secure_channel()
@@ -248,10 +240,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             servers = self.find_servers_on_network()
             self.close_secure_channel()
@@ -267,10 +255,6 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
-        except ua.UaStatusCodeError:
-            raise
-
-        try:
             self.open_secure_channel()
             self.create_session()
         except Exception:

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -76,15 +76,14 @@ class KeepAlive(Thread):
 
 
 class Client(object):
-
     """
     High level client to connect to an OPC-UA server.
 
     This class makes it easy to connect and browse address space.
-    It attemps to expose as much functionality as possible
-    but if you want more flexibility it is possible and adviced to
-    use UaClient object, available as self.uaclient
-    which offers the raw OPC-UA services interface.
+    It attempts to expose as much functionality as possible
+    but if you want more flexibility it is possible and advised to
+    use the UaClient object, available as self.uaclient, which offers
+    the raw OPC-UA services interface.
     """
 
     def __init__(self, url, timeout=4):
@@ -213,6 +212,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             endpoints = self.get_endpoints()
             self.close_secure_channel()
@@ -227,6 +230,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()  # spec says it should not be necessary to open channel
             servers = self.find_servers()
             self.close_secure_channel()
@@ -241,6 +248,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             servers = self.find_servers_on_network()
             self.close_secure_channel()
@@ -256,6 +267,10 @@ class Client(object):
         self.connect_socket()
         try:
             self.send_hello()
+        except ua.UaStatusCodeError:
+            raise
+
+        try:
             self.open_secure_channel()
             self.create_session()
         except Exception:
@@ -288,7 +303,10 @@ class Client(object):
         Send OPC-UA hello to server
         """
         ack = self.uaclient.send_hello(self.server_url.geturl(), self.max_messagesize, self.max_chunkcount)
-        # FIXME check ack
+
+        # TODO: Handle ua.UaError
+        if isinstance(ack, ua.UaStatusCodeError):
+            raise ack
 
     def open_secure_channel(self, renew=False):
         """

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -110,7 +110,7 @@ class UASocketClient(object):
         elif isinstance(msg, ua.Acknowledge):
             self._call_callback(0, msg)
         elif isinstance(msg, ua.ErrorMessage):
-            self.logger.warning("Received an error: %s", msg)
+            self._call_callback(0, ua.UaStatusCodeError(msg.Error.value))
         else:
             raise ua.UaError("Unsupported message type: %s", msg)
 

--- a/opcua/client/ua_client.py
+++ b/opcua/client/ua_client.py
@@ -110,6 +110,7 @@ class UASocketClient(object):
         elif isinstance(msg, ua.Acknowledge):
             self._call_callback(0, msg)
         elif isinstance(msg, ua.ErrorMessage):
+            self.logger.fatal("Received an error: %s", msg)
             self._call_callback(0, ua.UaStatusCodeError(msg.Error.value))
         else:
             raise ua.UaError("Unsupported message type: %s", msg)

--- a/opcua/common/connection.py
+++ b/opcua/common/connection.py
@@ -290,7 +290,6 @@ class SecureConnection(object):
             return msg
         elif header.MessageType == ua.MessageType.Error:
             msg = struct_from_binary(ua.ErrorMessage, body)
-            logger.warning("Received an error: %s", msg)
             return msg
         else:
             raise ua.UaError("Unsupported message type {0}".format(header.MessageType))

--- a/opcua/common/connection.py
+++ b/opcua/common/connection.py
@@ -290,6 +290,7 @@ class SecureConnection(object):
             return msg
         elif header.MessageType == ua.MessageType.Error:
             msg = struct_from_binary(ua.ErrorMessage, body)
+            logger.warning("Received an error: %s", msg)
             return msg
         else:
             raise ua.UaError("Unsupported message type {0}".format(header.MessageType))


### PR DESCRIPTION
I was having an issue catching OPC UA server error responses when trying to create an OPC UA client because the `UaStatusCodeError` would be logged in the socket thread and a `concurrent.futures.TimeoutError` would get thrown in the main process. By re-raising the `UaStatusCodeError`, the main process can catch it and provide more details as to why the client connection can not be established.

## Environment
**Server:** Instance of Prosys OPC UA Simulation Server in a Docker container. Set the Server Name to `pika`.

**Client code:**
```python
# Python 3.6
import concurrent.futures
import logging

import opcua
from opcua.ua import status_codes
from opcua.ua.uaerrors import UaStatusCodeError


logging.basicConfig(
    level=logging.INFO,
    format="%(asctime)s.%(msecs)03d [%(name)s] %(thread)d %(levelname)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S"
)
logging.getLogger("opcua").setLevel(logging.DEBUG)
log = logging.getLogger(__name__)


host = "localhost"
server_name = "missingno"   # should throw an error
url = f"opc.tcp://{host}:4906/{server_name}"


try:
    with opcua.Client(url, timeout=1) as client:
        log.info("Connection successful!")
except concurrent.futures.TimeoutError:
    log.info("Hmm... Socket timed out")
except UaStatusCodeError as e:
    name, doc = status_codes.get_name_and_doc(e.code)
    log.info(f"OPC UA server responded with error {name}: {doc}")
``` 

Logs from current behavior:
```
cryptography is not installed, use of crypto disabled
cryptography is not installed, use of crypto disabled
cryptography is not installed, use of crypto disabled
2018-12-04 17:18:51.071 [opcua.client.ua_client.Socket] 140735838761856 INFO - opening connection
2018-12-04 17:18:51.075 [opcua.client.ua_client.Socket] 123145344372736 INFO - Thread started
2018-12-04 17:18:51.075 [opcua.uaprotocol] 123145344372736 DEBUG - Waiting for header
2018-12-04 17:18:51.081 [opcua.uaprotocol] 123145344372736 INFO - received header: Header(type:b'ERR', chunk_type:b'F', body_size:123, channel:0)
2018-12-04 17:18:51.082 [opcua.uaprotocol] 123145344372736 WARNING - Received an error: MessageAbort(error:StatusCode(Good), reason:Bad_TcpEndpointUrlInvalid (code=0x80830000, description="The Server does not recognize the QueryString specified."))
2018-12-04 17:18:51.082 [opcua.client.ua_client.Socket] 123145344372736 WARNING - Received an error: MessageAbort(error:StatusCode(Good), reason:Bad_TcpEndpointUrlInvalid (code=0x80830000, description="The Server does not recognize the QueryString specified."))
2018-12-04 17:18:51.082 [opcua.uaprotocol] 123145344372736 DEBUG - Waiting for header
2018-12-04 17:18:51.082 [opcua.client.ua_client.Socket] 123145344372736 INFO - Socket has closed connection
2018-12-04 17:18:51.082 [opcua.client.ua_client.Socket] 123145344372736 INFO - Thread ended
2018-12-04 17:18:52.079 [opcua.client.ua_client.Socket] 140735838761856 INFO - Request to close socket received
2018-12-04 17:18:52.080 [opcua.client.ua_client.Socket] 140735838761856 INFO - Socket closed, waiting for receiver thread to terminate...
2018-12-04 17:18:52.080 [opcua.client.ua_client.Socket] 140735838761856 INFO - Done closing socket: Receiving thread terminated, socket disconnected
2018-12-04 17:18:52.080 [__main__] 140735838761856 INFO - Hmm... Socket timed out
```

Logs with changes:
```
cryptography is not installed, use of crypto disabled
cryptography is not installed, use of crypto disabled
cryptography is not installed, use of crypto disabled
2018-12-04 17:20:00.544 [opcua.client.ua_client.Socket] 140735838761856 INFO - opening connection
2018-12-04 17:20:00.548 [opcua.client.ua_client.Socket] 123145328926720 INFO - Thread started
2018-12-04 17:20:00.548 [opcua.uaprotocol] 123145328926720 DEBUG - Waiting for header
2018-12-04 17:20:00.556 [opcua.uaprotocol] 123145328926720 INFO - received header: Header(type:b'ERR', chunk_type:b'F', body_size:123, channel:0)
2018-12-04 17:20:00.556 [opcua.uaprotocol] 123145328926720 DEBUG - Waiting for header
2018-12-04 17:20:00.556 [__main__] 140735838761856 INFO - OPC UA server responded with error BadTcpEndpointUrlInvalid: The server does not recognize the QueryString specified.
2018-12-04 17:20:00.557 [opcua.client.ua_client.Socket] 123145328926720 INFO - Socket has closed connection
2018-12-04 17:20:00.557 [opcua.client.ua_client.Socket] 123145328926720 INFO - Thread ended
```