### PR TITLE
Hope to fix an import of type_definitions, and parentlink.

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -120,9 +120,9 @@ class XmlImporter(object):
             if ndata.parent:
                 ndata.parent = ua.NodeId.from_string(ndata.parent)
             if ndata.parentlink:
-                ndata.parentlink = self.to_nodeid(ndata.parentlink)
+                ndata.parentlink = self._to_nodeid(ndata.parentlink)
             if ndata.typedef:
-                ndata.typedef = self.to_nodeid(ndata.typedef)
+                ndata.typedef = self._to_nodeid(ndata.typedef)
             new_nodes.append(ndata)
         return new_nodes
 


### PR DESCRIPTION
Good Day developers, thank you again for your work!

Story:
I wanted to import an ObjectType and Object of this object type from XML 
![Snap of an XML_file](https://user-images.githubusercontent.com/38531666/54983858-eca9d380-4fad-11e9-80d3-061f0e904dc9.PNG)

and the issue was, that after server starts and import, an Object hast to references for "HasTypeDifinition", one of them pointing to wrong NodeID. 

![Wrong_Type](https://user-images.githubusercontent.com/38531666/54984486-3cd56580-4faf-11e9-8968-aecdb26925fa.PNG)


Long story short -- I was able to fix it and it seems like it was a typo:

In a previous code, the `_migrate_ns `function was called twice on reference_type: once in `make_objects `and once in `_get_node`. I fixed got rid of mitigation in `make_objects`, because I think originally developer wanted to call the privat `_to_nodeid ` method.

P.S. I'm not sure if parent link requires similar changes, because I don't know how to check it


