### PR TITLE
Fix object creation

### DIFF
--- a/opcua/common/manage_nodes.py
+++ b/opcua/common/manage_nodes.py
@@ -51,7 +51,7 @@ def create_object(parent, nodeid, bname, objecttype=None):
     nodeid, qname = _parse_nodeid_qname(nodeid, bname)
     if objecttype is not None:
         objecttype = node.Node(parent.server, objecttype)
-        dname = ua.LocalizedText(bname)
+        dname = ua.LocalizedText(qname.Name)
         nodes = instantiate(parent, objecttype, nodeid, bname=qname, dname=dname)[0]
         return nodes
     else:


### PR DESCRIPTION
Hi again, thank you developers for your work.

Issue: while creating object via `Node.add_object()`, the resulting object has either: Namespace index in DisplayName or Default Namespace 0 in BrowseName. I fixed it and checked functionality:

with the new version user can supply `bname` attribute to `Node.add_object()` as `QualifiedName`, as `QualifiedName.to_string()` and simple string and all versions worked properly.

Nevertheless, I'm not sure if my test are sufficient.