### PR TITLE
Set EnumStrings as property of custom enumeration datatype

### DIFF
--- a/examples/server-enum.py
+++ b/examples/server-enum.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     #                                                       ua.LocalizedText("idle")])
 
     # Or convert the existing IntEnum MyEnum
-    es = myenum_type.add_variable(0, "EnumStrings" , enum_to_stringlist(MyEnum))
+    es = myenum_type.add_property(0, "EnumStrings" , enum_to_stringlist(MyEnum))
 
     es.set_value_rank(1)
     es.set_array_dimensions([0])


### PR DESCRIPTION
In order to make the custom Enumeration work, it is needed that the `EnumString` is a property of the Enum data type. I got this by looking at the built-in server enumeration `ServerState`, where it the same case.
After this change, even UaExpert let me choose the enum from a drop-down list.
Also in the `ServerSate` datatype, there is a reference of `ModellingRule` set to `Mandatory`. I don't know if this is actually "mandatory" for the full functionality of the custom enumeration, but if so, add the additional line to create the reference:
```python
es.set_modelling_rule(ua.ObjectIds.ModellingRule_Mandatory)
```

Best regards,
testunde
