### PR TITLE
Fix Server-field access for server registration at discovery server

### DIFF
--- a/opcua/server/registration_service.py
+++ b/opcua/server/registration_service.py
@@ -110,7 +110,7 @@ class RegistrationService(object):
         if uaDiscoveryConfiguration is provided, the newer register_server2 service call is used
         """
         uaRegSrv = ua.RegisteredServer()
-        uaRegSrv.ServerUri = serverToRegister.application_uri
+        uaRegSrv.ServerUri = serverToRegister._application_uri
         uaRegSrv.ProductUri = serverToRegister.product_uri
         uaRegSrv.DiscoveryUrls = [serverToRegister.endpoint.geturl()]
         uaRegSrv.ServerType = serverToRegister.application_type

--- a/opcua/server/registration_service.py
+++ b/opcua/server/registration_service.py
@@ -110,7 +110,7 @@ class RegistrationService(object):
         if uaDiscoveryConfiguration is provided, the newer register_server2 service call is used
         """
         uaRegSrv = ua.RegisteredServer()
-        uaRegSrv.ServerUri = serverToRegister._application_uri
+        uaRegSrv.ServerUri = serverToRegister.get_application_uri()
         uaRegSrv.ProductUri = serverToRegister.product_uri
         uaRegSrv.DiscoveryUrls = [serverToRegister.endpoint.geturl()]
         uaRegSrv.ServerType = serverToRegister.application_type

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -165,6 +165,9 @@ class Server(object):
             uries.append(uri)
         ns_node.set_value(uries)
 
+    def set_application_uri_var(self, uri):
+        self._application_uri = uri
+
     def get_application_uri(self):
         return self._application_uri
 

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -165,6 +165,9 @@ class Server(object):
             uries.append(uri)
         ns_node.set_value(uries)
 
+    def get_application_uri(self):
+        return self._application_uri
+
     def find_servers(self, uris=None):
         """
         find_servers. mainly implemented for symmetry with client

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -165,9 +165,6 @@ class Server(object):
             uries.append(uri)
         ns_node.set_value(uries)
 
-    def set_application_uri_var(self, uri):
-        self._application_uri = uri
-
     def get_application_uri(self):
         return self._application_uri
 

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -166,6 +166,9 @@ class Server(object):
         ns_node.set_value(uries)
 
     def get_application_uri(self):
+        """
+        Get application/server URI.
+        """
         return self._application_uri
 
     def find_servers(self, uris=None):

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -521,8 +521,8 @@ class CommonTests(object):
         self.assertEqual([1], val)
 
     def test_use_namespace(self):
-        idx = self.opc.get_namespace_index("urn:freeopcua:python:server")
-        self.assertEqual(idx, 1)
+        idx = self.opc.get_namespace_index("http://opcfoundation.org/UA/")
+        self.assertEqual(idx, 0)
         root = self.opc.get_root_node()
         myvar = root.add_variable(idx, 'var_in_custom_namespace', [5])
         myid = myvar.nodeid

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -521,8 +521,10 @@ class CommonTests(object):
         self.assertEqual([1], val)
 
     def test_use_namespace(self):
-        idx = self.opc.get_namespace_index("http://opcfoundation.org/UA/")
-        self.assertEqual(idx, 0)
+        idx_orig = 1
+        uri = self.opc.get_namespace_array()[idx_orig]
+        idx = self.opc.get_namespace_index(uri)
+        self.assertEqual(idx_orig, idx)
         root = self.opc.get_root_node()
         myvar = root.add_variable(idx, 'var_in_custom_namespace', [5])
         myid = myvar.nodeid

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -53,7 +53,7 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
         try:
             servers = client.find_servers()
             new_app_uri = "urn:freeopcua:python:server:test_discovery"
-            self.srv.set_application_uri_var(new_app_uri)
+            self.srv.set_application_uri(new_app_uri)
             with RegistrationService() as regService:
                 regService.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 time.sleep(0.1)  # let server register registration
@@ -73,11 +73,11 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             with RegistrationService() as regService1, RegistrationService() as regService2:
                 # Register to server with uri1
                 new_app_uri1 = "urn:freeopcua:python:server:test_discovery1"
-                self.srv.set_application_uri_var(new_app_uri1)
+                self.srv.set_application_uri(new_app_uri1)
                 regService1.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Register to server with uri2
                 new_app_uri2 = "urn:freeopcua:python:test_discovery2"
-                self.srv.set_application_uri_var(new_app_uri2)
+                self.srv.set_application_uri(new_app_uri2)
                 regService2.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Check for 2 registrations
                 time.sleep(0.1)  # let server register registration

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -53,7 +53,7 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
         try:
             servers = client.find_servers()
             new_app_uri = "urn:freeopcua:python:server:test_discovery"
-            self.srv.application_uri = new_app_uri
+            self.srv.set_application_uri(new_app_uri)
             with RegistrationService() as regService:
                 regService.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 time.sleep(0.1)  # let server register registration
@@ -73,11 +73,11 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             with RegistrationService() as regService1, RegistrationService() as regService2:
                 # Register to server with uri1
                 new_app_uri1 = "urn:freeopcua:python:server:test_discovery1"
-                self.srv.application_uri = new_app_uri1
+                self.srv.set_application_uri(new_app_uri1)
                 regService1.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Register to server with uri2
                 new_app_uri2 = "urn:freeopcua:python:test_discovery2"
-                self.srv.application_uri = new_app_uri2
+                self.srv.set_application_uri(new_app_uri2)
                 regService2.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Check for 2 registrations
                 time.sleep(0.1)  # let server register registration

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -53,7 +53,7 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
         try:
             servers = client.find_servers()
             new_app_uri = "urn:freeopcua:python:server:test_discovery"
-            self.srv.set_application_uri(new_app_uri)
+            self.srv.set_application_uri_var(new_app_uri)
             with RegistrationService() as regService:
                 regService.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 time.sleep(0.1)  # let server register registration
@@ -73,11 +73,11 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
             with RegistrationService() as regService1, RegistrationService() as regService2:
                 # Register to server with uri1
                 new_app_uri1 = "urn:freeopcua:python:server:test_discovery1"
-                self.srv.set_application_uri(new_app_uri1)
+                self.srv.set_application_uri_var(new_app_uri1)
                 regService1.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Register to server with uri2
                 new_app_uri2 = "urn:freeopcua:python:test_discovery2"
-                self.srv.set_application_uri(new_app_uri2)
+                self.srv.set_application_uri_var(new_app_uri2)
                 regService2.register_to_discovery(self.srv, self.discovery.endpoint.geturl(), period=0)
                 # Check for 2 registrations
                 time.sleep(0.1)  # let server register registration


### PR DESCRIPTION
If I want to register my server to a discovery server, I get the following error:
```
Traceback (most recent call last):
  File "testServer.py", line 112, in <module>
    register.register_to_discovery(serverToRegister=server, discoveryUrl="opc.tcp://localhost:52010/discovery/")
  File "/usr/lib/python3.7/site-packages/opcua/server/registration_service.py", line 56, in register_to_discovery
    self._renew_registration(serverToRegister, registrationClient, period=period)
  File "/usr/lib/python3.7/site-packages/opcua/server/registration_service.py", line 80, in _renew_registration
    self._register_server(serverToRegister, registrationClient)
  File "/usr/lib/python3.7/site-packages/opcua/server/registration_service.py", line 113, in _register_server
    uaRegSrv.ServerUri = serverToRegister.application_uri
AttributeError: 'Server' object has no attribute 'application_uri'
```

To fix this, you can simply change the accessing line to the actual field-name (`serer._application_uri`, see this merge request), or it is possible to create a specific `server.get_application_uri()` method for the server class.

Best regards,
testunde