### PR TITLE
[subscriptions] Fix race condition in client when creating subs

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -39,7 +39,7 @@ class SessionState(Enum):
 
 class InternalServer(object):
 
-    def __init__(self, shelffile=None, parent=None):
+    def __init__(self, shelffile=None, parent=None, session_cls=None):
         self.logger = logging.getLogger(__name__)
 
         self._parent = parent
@@ -65,7 +65,8 @@ class InternalServer(object):
         self.history_manager = HistoryManager(self)
 
         # create a session to use on server side
-        self.isession = InternalSession(self, self.aspace, \
+        self.session_cls = session_cls or InternalSession
+        self.isession = self.session_cls(self, self.aspace, \
           self.subscription_service, "Internal", user=UserManager.User.Admin)
 
         self.current_time_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
@@ -134,7 +135,7 @@ class InternalServer(object):
         it2.TargetNodeClass = ua.NodeClass.Object
 
         results = self.isession.add_references([it, it2])
- 
+
     def load_address_space(self, path):
         """
         Load address space from path
@@ -195,7 +196,7 @@ class InternalServer(object):
         return self.endpoints[:]
 
     def create_session(self, name, user=UserManager.User.Anonymous, external=False):
-        return InternalSession(self, self.aspace, self.subscription_service, name, user=user, external=external)
+        return self.session_cls(self, self.aspace, self.subscription_service, name, user=user, external=external)
 
     def enable_history_data_change(self, node, period=timedelta(days=7), count=0):
         """
@@ -359,7 +360,7 @@ class InternalSession(object):
     def call(self, params):
         return self.iserver.method_service.call(params)
 
-    def create_subscription(self, params, callback):
+    def create_subscription(self, params, callback, ready_callback=None):
         result = self.subscription_service.create_subscription(params, callback)
         with self._lock:
             self.subscriptions.append(result.SubscriptionId)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,6 +8,7 @@ sys.path.insert(0, ".")
 from tests_cmd_lines import TestCmdLines
 from tests_server import TestServer, TestServerCaching, TestServerStartError
 from tests_client import TestClient
+from tests_subscriptions import SubscriptionTestCustomServer
 from tests_standard_address_space import StandardAddressSpaceTests
 from tests_unit import TestUnit, TestMaskEnum
 from tests_history import TestHistory, TestHistorySQL, TestHistoryLimits, TestHistorySQLLimits


### PR DESCRIPTION
Due to how Futures are used, we could timeout on the client side, but
still sucessfully create a subscription and add callbacks in the
_receiver thread. Once this happens, receiver thread will deadlock on
receiving the publish response from the server due to a while loop that
waits for the subscription_id to be set. This will never happen as it
was supposed to be set in the main thread, which timed out and failed.

The fix is to make sure we set the subscription_id in the _receiver
thread as a separate callback. This is not the ideal fix, which would
probably include re-designing the Subscription class API in a way to
allow checking for the staus, and changing the way
Client.create_subscription works. Since we don't want to make large
changes to this - let's just go with a simple fix that removes the
deadlock, and keeps the API pretty much compatible.

This commit also contains unittests that excercise the offending code
path and clearly avoids a deadlock.