### PR TITLE
Convert StatusCode value to name and doc on-the-fly

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -216,11 +216,9 @@ class StatusCode(FrozenClass):
 
     def __init__(self, value=0):
         if isinstance(value, str):
-            self.name = value
             self.value = getattr(status_codes.StatusCodes, value)
         else:
             self.value = value
-            self.name, self.doc = status_codes.get_name_and_doc(value)
         self._freeze = True
 
     def check(self):
@@ -241,6 +239,16 @@ class StatusCode(FrozenClass):
             return False
         else:
             return True
+
+    @property
+    def name(self):
+        name, _ = status_codes.get_name_and_doc(self.value)
+        return name
+
+    @property
+    def doc(self):
+        _, doc = status_codes.get_name_and_doc(self.value)
+        return doc
 
     def __str__(self):
         return 'StatusCode({0})'.format(self.name)

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -218,6 +218,18 @@ class TestUnit(unittest.TestCase):
         self.assertEqual(string_to_val(s_statuscode, ua.VariantType.StatusCode), statuscode)
         self.assertEqual(string_to_val(s_statuscode2, ua.VariantType.StatusCode), statuscode2)
 
+    def test_status_code_to_string(self):
+        # serialize a status code and deserialize it, name and doc resolution should work just fine
+        statuscode = ua.StatusCode(ua.StatusCodes.BadNotConnected)
+        statuscode2 = struct_from_binary(ua.StatusCode, io.BytesIO(struct_to_binary(ua.StatusCode(ua.StatusCodes.BadNotConnected))))
+
+        self.assertEqual(statuscode, statuscode2)
+        self.assertEqual(statuscode.value, statuscode2.value)
+
+        # properties that are not serialized should still translate properly
+        self.assertEqual(statuscode.name, statuscode2.name)
+        self.assertEqual(statuscode.doc, statuscode2.doc)
+
     def test_string_to_variant_qname(self):
         string = "2:name"
         obj = ua.QualifiedName("name", 2)


### PR DESCRIPTION
Otherwise StatusCode objects will carry a wrong name and doc after
deserialization.

Also add a test for proper resolution of name/doc from value.