### PR TITLE
Fix localtime field of events

### DIFF
--- a/opcua/common/event_objects.py
+++ b/opcua/common/event_objects.py
@@ -17,7 +17,7 @@ class BaseEvent(Event):
         self.add_property('SourceName', None, ua.VariantType.String)
         self.add_property('Time', None, ua.VariantType.DateTime)
         self.add_property('ReceiveTime', None, ua.VariantType.DateTime)
-        self.add_property('LocalTime', None, ua.VariantType.DateTime)
+        self.add_property('LocalTime', ua.NodeId(ua.ObjectIds.TimeZoneDataType), ua.VariantType.ExtensionObject)
         self.add_property('Message', ua.LocalizedText(message), ua.VariantType.LocalizedText)
         self.add_property('Severity', severity, ua.VariantType.UInt16)
 


### PR DESCRIPTION
Before, the localtime field was set to a wrong datatype (DateTime
instead of TimeZoneDataType), and didn’t contain the local timezone
offset, but the current localtime.