### PR TITLE
Use correct signature algorithm in create session response

### DIFF
--- a/opcua/crypto/security_policies.py
+++ b/opcua/crypto/security_policies.py
@@ -394,6 +394,7 @@ class SecurityPolicyBasic128Rsa15(SecurityPolicy):
     signature_key_size = 16
     symmetric_key_size = 16
     AsymmetricEncryptionURI = "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+    AsymmetricSignatureURI = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
     @staticmethod
     def encrypt_asymmetric(pubkey, data):
@@ -465,6 +466,7 @@ class SecurityPolicyBasic256(SecurityPolicy):
     signature_key_size = 24
     symmetric_key_size = 32
     AsymmetricEncryptionURI = "http://www.w3.org/2001/04/xmlenc#rsa-oaep"
+    AsymmetricSignatureURI = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
     @staticmethod
     def encrypt_asymmetric(pubkey, data):
@@ -533,6 +535,7 @@ class SecurityPolicyBasic256Sha256(SecurityPolicy):
     signature_key_size = 32
     symmetric_key_size = 32
     AsymmetricEncryptionURI = "http://www.w3.org/2001/04/xmlenc#rsa-oaep"
+    AsymmetricSignatureURI = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 
     @staticmethod
     def encrypt_asymmetric(pubkey, data):

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -140,7 +140,7 @@ class UaProcessor(object):
             response.Parameters.ServerSignature.Signature = \
                 self._connection.security_policy.asymmetric_cryptography.signature(data)
 
-            response.Parameters.ServerSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+            response.Parameters.ServerSignature.Algorithm = self._connection.security_policy.AsymmetricSignatureURI
 
             self.logger.info("sending create session response")
             self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)

--- a/opcua/ua/uaprotocol_hand.py
+++ b/opcua/ua/uaprotocol_hand.py
@@ -224,6 +224,7 @@ class SecurityPolicy(object):
     Base class for security policy
     """
     URI = "http://opcfoundation.org/UA/SecurityPolicy#None"
+    AsymmetricSignatureURI = ""
     signature_key_size = 0
     symmetric_key_size = 0
 


### PR DESCRIPTION
Previously this was hardcoded to sha1. Fix this by introducing a
new URI field in the SecurityPolicy classes carrying the correct
URIs.

This fixes complaints by some UA clients that match requested
security profiles against the server response and warn the user.