### PR TITLE
Fix import warning

### DIFF
--- a/opcua/common/callback.py
+++ b/opcua/common/callback.py
@@ -3,7 +3,7 @@
 server side implementation of callback event 
 """
 
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from enum import Enum
 
 class CallbackType(Enum):

--- a/opcua/common/xmlexporter.py
+++ b/opcua/common/xmlexporter.py
@@ -3,7 +3,7 @@ from a list of nodes in the address space, build an XML file
 format is the one from opc-ua specification
 """
 import logging
-from collections import OrderedDict
+from collections.abc import OrderedDict
 import xml.etree.ElementTree as Et
 from copy import copy
 import base64


### PR DESCRIPTION
Fix warning when importing 'collections'.
Warning will only appear in Python 3.7.
Please see:[https://docs.python.org/3/library/collections.html](https://docs.python.org/3/library/collections.html)

> Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.