### PR TITLE
Fix custom data type creation

### DIFF
--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -406,10 +406,25 @@ class Server(object):
             etype = BaseEvent()
         return EventGenerator(self.iserver.isession, etype, emitting_node=emitting_node)
 
-    def create_custom_data_type(self, idx, name, basetype=ua.ObjectIds.BaseDataType, properties=None):
+    def create_custom_data_type(self, idx, name, basetype=ua.ObjectIds.BaseDataType, properties=None, description=None):
         if properties is None:
             properties = []
-        return self._create_custom_type(idx, name, basetype, properties, [], [])
+
+        if isinstance(basetype, Node):
+            base_t = basetype
+        elif isinstance(basetype, ua.NodeId):
+            base_t = Node(self.iserver.isession, basetype)
+        else:
+            base_t = Node(self.iserver.isession, ua.NodeId(basetype))
+
+        custom_t = base_t.add_data_type(idx, name, description)
+        for prop in properties:
+            datatype = None
+            if len(prop) > 2:
+                datatype = prop[2]
+            custom_t.add_property(idx, prop[0], ua.get_default_value(prop[1]), varianttype=prop[1], datatype=datatype)
+
+        return custom_t
 
     def create_custom_event_type(self, idx, name, basetype=ua.ObjectIds.BaseEventType, properties=None):
         if properties is None:

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -327,7 +327,7 @@ class TestServer(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
     # For the custom events all posibilites are tested. For other custom types only one test case is done since they are using the same code
     def test_create_custom_data_type_ObjectId(self):
         type = self.opc.create_custom_data_type(2, 'MyDataType', ua.ObjectIds.BaseDataType, [('PropertyNum', ua.VariantType.Int32), ('PropertyString', ua.VariantType.String)])
-        check_custom_type(self, type, ua.ObjectIds.BaseDataType)
+        check_custom_type(self, type, ua.ObjectIds.BaseDataType, ua.NodeClass.DataType)
 
     def test_create_custom_event_type_ObjectId(self):
         type = self.opc.create_custom_event_type(2, 'MyEvent', ua.ObjectIds.BaseEventType, [('PropertyNum', ua.VariantType.Int32), ('PropertyString', ua.VariantType.String)])
@@ -571,12 +571,16 @@ def check_custom_event(test, ev, etype):
     test.assertEqual(ev.Severity, 1)
 
 
-def check_custom_type(test, type, base_type):
+def check_custom_type(test, type, base_type, node_class=None):
     base = opcua.Node(test.opc.iserver.isession, ua.NodeId(base_type))
     test.assertTrue(type in base.get_children())
     nodes = type.get_referenced_nodes(refs=ua.ObjectIds.HasSubtype, direction=ua.BrowseDirection.Inverse, includesubtypes=True)
     test.assertEqual(base, nodes[0])
     properties = type.get_properties()
+
+    if node_class:
+        test.assertEqual(node_class, type.get_node_class())
+
     test.assertIsNot(properties, None)
     test.assertEqual(len(properties), 2)
     test.assertTrue(type.get_child("2:PropertyNum") in properties)

--- a/tests/tests_server.py
+++ b/tests/tests_server.py
@@ -2,12 +2,12 @@ import unittest
 import os
 import shelve
 import time
-from enum import Enum, EnumMeta
+from enum import EnumMeta
 
 from tests_common import CommonTests, add_server_methods
 from tests_xml import XmlTests
 from tests_subscriptions import SubscriptionTests
-from datetime import timedelta, datetime
+from datetime import timedelta
 from tempfile import NamedTemporaryFile
 
 import opcua


### PR DESCRIPTION
The `create_custom_data_type` method of the `opcua.Server` creates a node with class node "ObjectType", which is incorrect. This PR fixes this issue.