### PR TITLE
Bugfix: Node.set_value() does not work with enumerations

### DIFF
--- a/opcua/common/node.py
+++ b/opcua/common/node.py
@@ -209,10 +209,18 @@ class Node(object):
         elif isinstance(value, ua.Variant):
             datavalue = ua.DataValue(value)
             datavalue.SourceTimestamp = datetime.utcnow()
+        elif varianttype is None:
+            # Use the data type of the node (self) if no data type is given. 
+            varianttype = self.get_data_type_as_variant_type()
+            datavalue = ua.DataValue(ua.Variant(value, varianttype))
+            datavalue.SourceTimestamp = datetime.utcnow()
         else:
             datavalue = ua.DataValue(ua.Variant(value, varianttype))
             datavalue.SourceTimestamp = datetime.utcnow()
+
         self.set_attribute(ua.AttributeIds.Value, datavalue)
+
+    set_data_value = set_value
 
     set_data_value = set_value
 


### PR DESCRIPTION
If a client tries to set a enum variable without explicitly force the data type it becomes implicit converted to a ua.Variant.Int64. The server expects an Int32 for an enum value. This is why set_value() crashes if you try to set an enum value using a integer literal like "set_value(2)".

The enumeration seems to need a special treadment at this point. See ua_utils.py def data_type_to_variant_type().

If no data type was given in method set_value(), this change checks the data type of the node object and automatically converts the value argument to the correct target data type of the server.