### PR TITLE
Fix WhereClauseEvauluator

### DIFF
--- a/opcua/server/internal_subscription.py
+++ b/opcua/server/internal_subscription.py
@@ -423,30 +423,29 @@ class WhereClauseEvaluator(object):
         # ops = [self._eval_op(op, event) for op in el.FilterOperands]
         ops = el.FilterOperands  # just to make code more readable
         if el.FilterOperator == ua.FilterOperator.Equals:
-            return self._eval_op(ops[0], event) == self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) == self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.IsNull:
             return self._eval_op(ops[0], event) is None  # FIXME: might be too strict
         elif el.FilterOperator == ua.FilterOperator.GreaterThan:
-            return self._eval_op(ops[0], event) > self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) > self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.LessThan:
-            return self._eval_op(ops[0], event) < self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) < self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.GreaterThanOrEqual:
-            return self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) >= self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.LessThanOrEqual:
-            return self._eval_op(ops[0], event) <= self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) <= self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.Like:
-            return self._likeoperator(self._eval_op(ops[0], event), self._eval_el(ops[1], event))
+            return self._likeoperator(self._eval_op(ops[0], event), self._eval_op(ops[1], event))
         elif el.FilterOperator == ua.FilterOperator.Not:
             return not self._eval_op(ops[0], event)
         elif el.FilterOperator == ua.FilterOperator.Between:
-            return self._eval_el(ops[2], event) >= self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
+            return self._eval_el(ops[2], event) >= self._eval_op(ops[0], event) >= self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.InList:
             return self._eval_op(ops[0], event) in [self._eval_op(op, event) for op in ops[1:]]
         elif el.FilterOperator == ua.FilterOperator.And:
-            self.elements(ops[0].Index)
             return self._eval_op(ops[0], event) and self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.Or:
-            return self._eval_op(ops[0], event) or self._eval_el(ops[1], event)
+            return self._eval_op(ops[0], event) or self._eval_op(ops[1], event)
         elif el.FilterOperator == ua.FilterOperator.Cast:
             self.logger.warn("Cast operand not implemented, assuming True")
             return True


### PR DESCRIPTION
There were two major issues. First, _eval_el was called instead of _eval_op in recursive
calls, which would always fail.

Secondly, there was a misplaced line of code in "and" evaluation in _eval_el, which would
cause it to always fail.