### PR TITLE
Handle lists of multiple types in ua.Variant._guess_type

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -770,23 +770,19 @@ class Variant(FrozenClass):
         return not self.__eq__(other)
 
     def _guess_type(self, val):
-
         if isinstance(val, (list, tuple)):
             error_val = val
-
-            # Guess the type of a list of lists using the first list
-            while isinstance(val[0], (list, tuple)):
+            while val and isinstance(val[0], (list, tuple)):
                 val = val[0]
 
             types = {type(el) for el in val}
-
             if len(types) == 0:
                 raise UaError("List of zero length. Could not guess UA type of variable {0}".format(error_val))
             elif types == set([int, float]):
                 logger.warning(
                     "Variable {0} has ints and floats. UA type will be {1}".format(error_val, VariantType.Double)
                 )
-                val = float(val[0])
+                val = float()
             elif len(types) > 1:
                 raise UaError("List of multiple types. Could not guess UA type of variable {0}".format(error_val))
             else:

--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -779,7 +779,7 @@ class Variant(FrozenClass):
             if len(types) == 0:
                 raise UaError("List of zero length. Could not guess UA type of variable {0}".format(error_val))
             elif types == set([int, float]):
-                logger.warning(
+                logger.debug(
                     "Variable {0} has ints and floats. UA type will be {1}".format(error_val, VariantType.Double)
                 )
                 val = float()


### PR DESCRIPTION
Thank you for taking the time to review my PR!

### Summary
* When guessing the type of a list, look at the type of every element, not just the first one.
* Raise an error if there are multiple types, unless the types are `int` and `float`.
* Lists of `int` and `float` are treated as `float`.
* Tests for the above.

### Motivation
While working with some device drivers, I was seeing errors with long stack traces and the message:

    struct.error: required argument is not an integer

This was caused by writing lists of coordinates in which not every element has decimal precision. I found it perplexing that I wouldn't see the error with:

    [-110.1,0,64.25,180,0,180]
but would with:

    [-110,0,64.25,180,0,180]


### Additional Notes
This is converting `[1, 2.0, 3]` to `[1.0, 2.0, 3.0]` with just a `debug` to show for it. That kind of conversion already happens for lists like `[1.0, 2, 3]` (which would become `[1.0, 2.0, 3.0]`) but I can see the case for cutting that `elif` and just raising an exception.