### PR TITLE
Opc publisher support

### DIFF
--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -476,6 +476,22 @@ class UaProcessor(object):
 
             self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
 
+        elif typeid == ua.NodeId(ua.ObjectIds.SetPublishingModeRequest_Encoding_DefaultBinary):
+            self.logger.info("set publishing mode request")
+
+            params = struct_from_binary(ua.SetPublishingModeParameters, body)
+
+            # Send dummy results to keep clients happy
+            response = ua.SetPublishingModeResponse()
+            results = ua.SetPublishingModeResult()
+            ids = params.SubscriptionIds
+            statuses = [ua.StatusCode(ua.StatusCodes.Good) for node_id in ids]
+            results.Results = statuses
+            response.Parameters = results
+
+            self.logger.info("sending set publishing mode response")
+            self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
+
         else:
             self.logger.warning("Unknown message received %s", typeid)
             raise utils.ServiceError(ua.StatusCodes.BadServiceUnsupported)

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -481,6 +481,7 @@ class UaProcessor(object):
 
             params = struct_from_binary(ua.SetMonitoringModeParameters, body)
 
+            # FIXME: Implement SetMonitoringMode
             # Send dummy results to keep clients happy
             response = ua.SetMonitoringModeResponse()
             results = ua.SetMonitoringModeResult()
@@ -497,6 +498,7 @@ class UaProcessor(object):
 
             params = struct_from_binary(ua.SetPublishingModeParameters, body)
 
+            # FIXME: Implement.SetPublishingMode
             # Send dummy results to keep clients happy
             response = ua.SetPublishingModeResponse()
             results = ua.SetPublishingModeResult()

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -476,6 +476,22 @@ class UaProcessor(object):
 
             self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
 
+        elif typeid == ua.NodeId(ua.ObjectIds.SetMonitoringModeRequest_Encoding_DefaultBinary):
+            self.logger.info("set monitoring mode request")
+
+            params = struct_from_binary(ua.SetMonitoringModeParameters, body)
+
+            # Send dummy results to keep clients happy
+            response = ua.SetMonitoringModeResponse()
+            results = ua.SetMonitoringModeResult()
+            ids = params.MonitoredItemIds
+            statuses = [ua.StatusCode(ua.StatusCodes.Good) for node_id in ids]
+            results.Results = statuses
+            response.Parameters = results
+
+            self.logger.info("sending set monitoring mode response")
+            self.send_response(requesthdr.RequestHandle, algohdr, seqhdr, response)
+
         elif typeid == ua.NodeId(ua.ObjectIds.SetPublishingModeRequest_Encoding_DefaultBinary):
             self.logger.info("set publishing mode request")
 

--- a/opcua/server/uaprocessor.py
+++ b/opcua/server/uaprocessor.py
@@ -498,7 +498,7 @@ class UaProcessor(object):
 
             params = struct_from_binary(ua.SetPublishingModeParameters, body)
 
-            # FIXME: Implement.SetPublishingMode
+            # FIXME: Implement SetPublishingMode
             # Send dummy results to keep clients happy
             response = ua.SetPublishingModeResponse()
             results = ua.SetPublishingModeResult()


### PR DESCRIPTION
Allows `python-opcua` to be used with [OPC Publisher Edge Module](https://github.com/Azure/Industrial-IoT/blob/master/docs/modules/publisher.md) by stubbing `SetPublishingMode` and `SetMonitoringMode`:

NOTE: This pull request does **not** implement `SetMonitoringMode`, nor `SetPublishingMode` functionality.

Related issue:
[WARNING:opcua.server.uaprocessor:Unknown message received FourByteNodeId(i=769)](https://github.com/FreeOpcUa/python-opcua/issues/594)