### PR TITLE
Properly shut down ThreadLoop

### DIFF
--- a/opcua/common/utils.py
+++ b/opcua/common/utils.py
@@ -156,6 +156,10 @@ class ThreadLoop(threading.Thread):
         """
         self.loop.call_soon_threadsafe(self.loop.stop)
 
+    def close(self):
+        self.loop.close()
+        self.loop = None
+
     def call_soon(self, callback):
         self.loop.call_soon_threadsafe(callback)
 

--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -184,11 +184,14 @@ class InternalServer(object):
     def stop(self):
         self.logger.info("stopping internal server")
         self.isession.close_session()
-        if self.loop:
-            self.loop.stop()
-            self.loop = None
         self.subscription_service.set_loop(None)
         self.history_manager.stop()
+        if self.loop:
+            self.loop.stop()
+            # wait for ThreadLoop to finish before proceeding
+            self.loop.join()
+            self.loop.close()
+            self.loop = None
 
     def is_running(self):
         return self.loop is not None


### PR DESCRIPTION
Stopping the InternalServer object should be a synchrounous call (once
the call returns the caller can be sure that the server if fully
stopped).

Hence, instead of just pushing a stop callback into the ThreadLoop wait
for the ThreadLoop to finish before returning.

Also re-order the shutdown to match the setup code.