### PR TITLE
Fix OperationLimits data type to UInt32

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -152,7 +152,7 @@ class InternalServer(object):
             attr = ua.WriteValue()
             attr.NodeId = ua.NodeId(nodeid)
             attr.AttributeId = ua.AttributeIds.Value
-            attr.Value = ua.DataValue(ua.Variant(10000), ua.StatusCode(ua.StatusCodes.Good))
+            attr.Value = ua.DataValue(ua.Variant(10000, ua.VariantType.UInt32), ua.StatusCode(ua.StatusCodes.Good))
             attr.Value.ServerTimestamp = datetime.utcnow()
             params.NodesToWrite.append(attr)
         result = self.isession.write(params)


### PR DESCRIPTION
According to OPC Unified Architecture, Part 5, 6.3.11
OperationLimitsType all Max* properties shall have datatype
UInt32.

Fix this by explicitly setting the variant type to UInt32
instead of defaulting to Int64.

This fixes connectivity issues with the KepwareServerEx OPC-UA client.

Introduced in 21432df9fb02bbd3e45d7fe2b4023d76db94738f