### PR TITLE
fix: itemId counter incremented twice

### DIFF
--- a/opcua/server/internal_subscription.py
+++ b/opcua/server/internal_subscription.py
@@ -99,7 +99,6 @@ class MonitoredItemService(object):
     def _commit_monitored_item(self, result, mdata):
         if result.StatusCode.is_good():
             self._monitored_items[result.MonitoredItemId] = mdata
-            self._monitored_item_counter += 1
 
     def _make_monitored_item_common(self, params):
         result = ua.MonitoredItemCreateResult()


### PR DESCRIPTION
During creating of a monitored item, the itemId counter is incremented twice:
Here:
https://github.com/FreeOpcUa/python-opcua/blob/bcb3e2d5966611f1efce3f179963147792a7fcd7/opcua/server/internal_subscription.py#L99-L102
and here:
https://github.com/FreeOpcUa/python-opcua/blob/bcb3e2d5966611f1efce3f179963147792a7fcd7/opcua/server/internal_subscription.py#L104-L110

Fix: Only increment when `result.MonitoredItemId` is assigned to `MonitoredItemCreateResult`