### PR TITLE
Fixed typo relevant for server endpoint security in set_security_IDs …

### DIFF
--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -224,7 +224,7 @@ class Server(object):
 
             E.g. to limit the number of IDs and disable anonymous clients:
 
-                set_security_policy(["Basic256Sha256"])
+                set_security_IDs(["Basic256Sha256"])
 
             (Implementation for ID check is currently not finalized...)
 


### PR DESCRIPTION
Typo in example may lead someone to wrongly believe that server.set_security_policy() also determines authentication options.
