### PR TITLE
Subscription: Method to reconciliate MonitoredItems

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -543,6 +543,20 @@ class Client(object):
         params.Priority = 0
         return Subscription(self.uaclient, params, handler)
 
+    def reconciliate_subscription(self, subscription):
+        """
+        Reconciliate the server state with the client
+        """
+        node = self.get_node(
+            ua.FourByteNodeId(ua.ObjectIds.Server_GetMonitoredItems)
+        )
+        # returns server and client handles
+        monitored_items = node.get_parent().call_method(
+            ua.uatypes.QualifiedName("GetMonitoredItems"),
+            ua.Variant(subscription.subscription_id, ua.datatype_to_varianttype(7))
+        )
+        return subscription.reconciliate(monitored_items)
+
     def get_namespace_array(self):
         ns_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
         return ns_node.get_value()

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -85,7 +85,7 @@ class Subscription(object):
         self._monitoreditems_map = {}
         self._lock = Lock()
         self.subscription_id = None
-        self.unknown_handler = False
+        self.has_unknown_handlers = False
         response = self.server.create_subscription(
             params, self.publish_callback, ready_callback=self.ready_callback)
         # Set it here to keep the old behavof as well, but this may not run if
@@ -140,7 +140,7 @@ class Subscription(object):
             with self._lock:
                 if item.ClientHandle not in self._monitoreditems_map:
                     self.logger.warning("Received a notification for unknown handle: %s", item.ClientHandle)
-                    self.unknown_handler = True
+                    self.has_unknown_handlers = True
                     continue
                 data = self._monitoreditems_map[item.ClientHandle]
             if hasattr(self._handler, "datachange_notification"):
@@ -380,5 +380,5 @@ class Subscription(object):
             # fail silenty if the MI has already been removed
             except ua.uaerrors._auto.BadMonitoredItemIdInvalid:
                 pass
-        self.unknown_handler = False
+        self.has_unknown_handlers = False
         return len(client_handler_to_del)


### PR DESCRIPTION
A method to reconciliate the client monitored_items with its server counterpart.

OPC-UA part 4 5.12.2.1 defines:

> If a Client called CreateMonitoredItems during the network interruption and the call succeeded in the Server but did not return to the Client, then the Client does not know if the call succeeded. The Client may receive data changes for these monitored items but is not able to remove them since it does not know the Server handle for each monitored item. There is also no way for the Client to detect if the create succeeded. To delete and recreate the Subscription is also not an option since there may be several monitored items operating normally that should not be interrupted. To resolve this situation, the Server Object provides a Method GetMonitoredItems that returns the list of server and client handles for the monitored items in a Subscription. This Method is defined in Part 5. The Server shall verify that the Method is called within the Session context of the Session that owns the Subscription.

[GetMonitoredItems](https://reference.opcfoundation.org/v104/Core/docs/Part5/9.1/) is defined in Part 5 hence is a standard implementation. However it's not mentioned that the order of both array of handlers is preserved but seems obvious to me.

The idea is to be able for the client to do the following:

```python3
if sub.unknown_handler:
    client.remediate_subscription(sub)
```

Thus we can alleviate the server from keeping track of unnecessary mi and resolve this noisy conflict that can grow over time:

`subscription.py:141] Received a notification for unknown handle: XXX`

