### PR TITLE
TypeError on method call with no inputArguments. Added case to handle this.

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -463,6 +463,8 @@ class MethodService(object):
                 res.StatusCode = ua.StatusCode(ua.StatusCodes.BadNothingToDo)
             else:
                 try:
+                    if method.InputArguments is None:
+                        method.InputArguments = [] 
                     result = node.call(method.ObjectId, *method.InputArguments)
                     if isinstance(result, ua.CallMethodResult):
                         res = result


### PR DESCRIPTION
Closes Issue [963](https://github.com/FreeOpcUa/python-opcua/issues/963)