### PR TITLE
[Reconciliate MI] Add tests and fix nits

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -548,12 +548,12 @@ class Client(object):
         Reconciliate the server state with the client
         """
         node = self.get_node(
-            ua.FourByteNodeId(ua.ObjectIds.Server_GetMonitoredItems)
+            ua.FourByteNodeId(ua.ObjectIds.Server)
         )
         # returns server and client handles
-        monitored_items = node.get_parent().call_method(
+        monitored_items = node.call_method(
             ua.uatypes.QualifiedName("GetMonitoredItems"),
-            ua.Variant(subscription.subscription_id, ua.datatype_to_varianttype(7))
+            ua.Variant(subscription.subscription_id, ua.VariantType.UInt32)
         )
         return subscription.reconciliate(monitored_items)
 

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -543,6 +543,20 @@ class Client(object):
         params.Priority = 0
         return Subscription(self.uaclient, params, handler)
 
+    def reconciliate_subscription(self, subscription):
+        """
+        Reconciliate the server state with the client
+        """
+        node = self.get_node(
+            ua.FourByteNodeId(ua.ObjectIds.Server_GetMonitoredItems)
+        )
+        # returns server and client handles
+        monitored_items = node.get_parent().call_method(
+            ua.uatypes.QualifiedName("GetMonitoredItems"),
+            ua.Variant(subscription.subscription_id, ua.datatype_to_varianttype(7))
+        )
+        return subscription.reconciliate(monitored_items)
+
     def get_namespace_array(self):
         ns_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
         return ns_node.get_value()

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -378,7 +378,7 @@ class Subscription(object):
             try:
                 self.unsubscribe(item)
             # fail silenty if the MI has already been removed
-            except ua.uaerrors._auto.BadMonitoredItemIdInvalid:
+            except ua.uaerrors.BadMonitoredItemIdInvalid:
                 pass
         self.has_unknown_handlers = False
         return len(client_handler_to_del)

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -85,7 +85,7 @@ class Subscription(object):
         self._monitoreditems_map = {}
         self._lock = Lock()
         self.subscription_id = None
-        self.unknown_handler = False
+        self.has_unknown_handlers = False
         response = self.server.create_subscription(
             params, self.publish_callback, ready_callback=self.ready_callback)
         # Set it here to keep the old behavof as well, but this may not run if
@@ -140,7 +140,7 @@ class Subscription(object):
             with self._lock:
                 if item.ClientHandle not in self._monitoreditems_map:
                     self.logger.warning("Received a notification for unknown handle: %s", item.ClientHandle)
-                    self.unknown_handler = True
+                    self.has_unknown_handlers = True
                     continue
                 data = self._monitoreditems_map[item.ClientHandle]
             if hasattr(self._handler, "datachange_notification"):
@@ -380,5 +380,5 @@ class Subscription(object):
             # fail silenty if the MI has already been removed
             except ua.uaerrors._auto.BadMonitoredItemIdInvalid:
                 pass
-        self.unknown_handler = False
+        self.has_unknown_handlers = False
         return len(client_handler_to_del)


### PR DESCRIPTION
Add unit test for the client / subscription reconciliate methods.

Also fix some nits raised here: https://github.com/FreeOpcUa/python-opcua/commit/de6a5185bcec893136d6e493b87753779657eea2#commitcomment-37372079