### PR TITLE
[Reconciliate MI] Add tests and fix nits

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -548,12 +548,12 @@ class Client(object):
         Reconciliate the server state with the client
         """
         node = self.get_node(
-            ua.FourByteNodeId(ua.ObjectIds.Server_GetMonitoredItems)
+            ua.FourByteNodeId(ua.ObjectIds.Server)
         )
         # returns server and client handles
-        monitored_items = node.get_parent().call_method(
+        monitored_items = node.call_method(
             ua.uatypes.QualifiedName("GetMonitoredItems"),
-            ua.Variant(subscription.subscription_id, ua.datatype_to_varianttype(7))
+            ua.Variant(subscription.subscription_id, ua.VariantType.UInt32)
         )
         return subscription.reconciliate(monitored_items)
 

--- a/opcua/common/subscription.py
+++ b/opcua/common/subscription.py
@@ -378,7 +378,7 @@ class Subscription(object):
             try:
                 self.unsubscribe(item)
             # fail silenty if the MI has already been removed
-            except ua.uaerrors._auto.BadMonitoredItemIdInvalid:
+            except ua.uaerrors.BadMonitoredItemIdInvalid:
                 pass
         self.has_unknown_handlers = False
         return len(client_handler_to_del)

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest import mock
 
 from opcua import Client
 from opcua import Server
@@ -12,6 +11,11 @@ from tests_common import CommonTests, add_server_methods
 from tests_xml import XmlTests
 
 from tests_enum_struct import add_server_custom_enum_struct
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 port_num1 = 48510
 

--- a/tests/tests_client.py
+++ b/tests/tests_client.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from opcua import Client
 from opcua import Server
@@ -6,7 +7,7 @@ from opcua import ua
 from opcua.client.ua_client import UASocketClient
 from opcua.common.utils import SocketWrapper
 
-from tests_subscriptions import SubscriptionTests
+from tests_subscriptions import SubscriptionTests, SubHandler
 from tests_common import CommonTests, add_server_methods
 from tests_xml import XmlTests
 
@@ -152,3 +153,24 @@ class TestClient(unittest.TestCase, CommonTests, SubscriptionTests, XmlTests):
         val = myvar.get_value()
         self.assertEqual(val.IntVal1, 242)
         self.assertEqual(val.EnumVal, ua.ExampleEnum.EnumVal2)
+
+    @mock.patch("opcua.common.subscription.Subscription.reconciliate")
+    @mock.patch("opcua.common.node.Node.call_method")
+    def test_reconciliate(self, mock_call_method, mock_reconciliate):
+        get_mi_response = [[1, 2], [201, 202]]
+        mock_call_method.return_value = get_mi_response
+
+        myhandler = SubHandler()
+        sub = self.opc.create_subscription(100, myhandler)
+        self.clt.reconciliate_subscription(sub)
+
+        node_called_args = mock_call_method.call_args[0]
+        self.assertEqual(
+            node_called_args[0], ua.uatypes.QualifiedName("GetMonitoredItems")
+        )
+        self.assertEqual(
+            node_called_args[1], ua.Variant(sub.subscription_id, ua.VariantType.UInt32)
+        )
+
+        reconciliate_called_args = mock_reconciliate.call_args[0][0]
+        self.assertEqual(reconciliate_called_args, get_mi_response)

--- a/tests/tests_subscriptions.py
+++ b/tests/tests_subscriptions.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime, timedelta
 from copy import copy
 import unittest
+from unittest import mock
 
 import opcua
 from opcua import Client
@@ -595,6 +596,22 @@ class SubscriptionTests(object):
         sub.unsubscribe(handle)
         sub.delete()
 
+    def test_subscription_reconciliate(self):
+        myhandler = SubHandler()
+        sub = self.opc.create_subscription(100, myhandler)
+        sub.has_unknown_handlers = True
+        get_mi_response = [[1, 2, 3, 4], [301, 201, 202, 302]]
+        mi_map = {301: myhandler, 302: myhandler}
+        sub.unsubscribe = mock.Mock()
+        with mock.patch.dict(sub._monitoreditems_map, mi_map):
+            mi_del = sub.reconciliate(get_mi_response)
+            mi_srv_only = set(get_mi_response[1]) - set(mi_map.keys())
+            for mi_handler in (2, 3):
+                self.assertIn(mock.call(mi_handler), sub.unsubscribe.call_args_list)
+            for mi_handler in (1, 4):
+                self.assertNotIn(mock.call(mi_handler), sub.unsubscribe.call_args_list)
+            self.assertEqual(mi_del, len(mi_srv_only))
+            self.assertFalse(sub.has_unknown_handlers)
 
 class CustomInternalSession(InternalSession):
     TIMEOUT = 4

--- a/tests/tests_subscriptions.py
+++ b/tests/tests_subscriptions.py
@@ -3,13 +3,17 @@ import time
 from datetime import datetime, timedelta
 from copy import copy
 import unittest
-from unittest import mock
 
 import opcua
 from opcua import Client
 from opcua import Server
 from opcua import ua
 from opcua.server.internal_server import InternalServer, InternalSession
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class SubHandler():


### PR DESCRIPTION
Add unit test for the client / subscription reconciliate methods.

Also fix some nits raised here: https://github.com/FreeOpcUa/python-opcua/commit/de6a5185bcec893136d6e493b87753779657eea2#commitcomment-37372079