### PR TITLE
Introduces 'is_connected' client call. Fixes #521

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -652,3 +652,9 @@ class Client(object):
         for result in results:
             result.check()
 
+    def is_connected(self):
+        """
+        Get OPC-UA client connection status.
+        """
+        return self.uaclient._uasocket._thread.isAlive()
+


### PR DESCRIPTION
In applications involving subscribing to data and waiting for data to stream in, there's no clear way to check if the client has been disconnected (for example, by shutting down the OPC-UA server).

This function isn't intended to check if a connection was initially successful (although theoretically it would do that too) - the intention is to check to see if the connection has been _dropped_.

Usage Pattern:
In my application, after 10 seconds with no new incoming data from the subscription, I check to see if the connection is alive. If it's still alive, it's just a lull in data, but if it's dead, we need to disconnect, reconnect and resubscribe to keep up-to-date with new data. 