### PR TITLE
bugfix: TwoByteNodeId does not encode namespace index

### DIFF
--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -81,6 +81,7 @@ def _instantiate_node(server,
         addnode.NodeAttributes.DisplayName = dname
 
     res = server.add_nodes([addnode])[0]
+    res.StatusCode.check()
     added_nodes = [res.AddedNodeId]
 
     if recursive:

--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -301,7 +301,10 @@ class NodeId(object):
         self._freeze = True
         if self.Identifier is None:
             self.Identifier = 0
-            self.NodeIdType = NodeIdType.TwoByte
+            if namespaceidx == 0:
+                self.NodeIdType = NodeIdType.TwoByte
+            else:  # TwoByte NodeId does not encode namespace.
+                self.NodeIdType = NodeIdType.Numeric
             return
         if self.NodeIdType is None:
             if isinstance(self.Identifier, int):


### PR DESCRIPTION
cfr. https://github.com/FreeOpcUa/python-opcua/issues/822

`ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex)` defaults to` NodeIdType == TwoByteNodeId`. However, `TwoByteNodeId` does not encode the namespaceindex when serializing to binary. As a result, clients requests with null-identifier and nsidx != 0 (e.g. during instantiation of object types) will be decoded with nsidx=0 at server side.

https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.2/#Table8