### PR TITLE
FEATURE: Allow to save to file that doesn't exist

### DIFF
--- a/opcua/common/structures.py
+++ b/opcua/common/structures.py
@@ -184,7 +184,7 @@ class StructGenerator(object):
             self.model.append(struct)
 
     def save_to_file(self, path, register=False):
-        _file = open(path, "wt")
+        _file = open(path, "w+")
         self._make_header(_file)
         for struct in self.model:
             _file.write(struct.get_code())


### PR DESCRIPTION
If file in path doesn't exist, it won't be created. "t" is not needed as a default option.