### PR TITLE
FIX: Missing "cryptography" warning moved to class

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -23,7 +23,6 @@ use_crypto = True
 try:
     from opcua.crypto import uacrypto
 except ImportError:
-    logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
     use_crypto = False
 
 
@@ -89,6 +88,9 @@ class Client(object):
     use the UaClient object, available as self.uaclient, which offers
     the raw OPC-UA services interface.
     """
+
+    if use_crypto is False:
+        logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
 
     def __init__(self, url, timeout=4):
         """

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -31,7 +31,6 @@ use_crypto = True
 try:
     from opcua.crypto import uacrypto
 except ImportError:
-    logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
     use_crypto = False
 
 
@@ -74,6 +73,9 @@ class Server(object):
     :vartype nodes: Shortcuts
 
     """
+
+    if use_crypto is False:
+        logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
 
     def __init__(self, shelffile=None, iserver=None):
         self.logger = logging.getLogger(__name__)

--- a/opcua/server/user_manager.py
+++ b/opcua/server/user_manager.py
@@ -7,11 +7,13 @@ use_crypto = True
 try:
     from opcua.crypto import uacrypto
 except ImportError:
-    logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
     use_crypto = False
 
 
 class UserManager(object):
+
+    if use_crypto is False:
+        logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
 
     class User(Enum):
         """

--- a/opcua/server/user_manager.py
+++ b/opcua/server/user_manager.py
@@ -12,9 +12,6 @@ except ImportError:
 
 class UserManager(object):
 
-    if use_crypto is False:
-        logging.getLogger(__name__).warning("cryptography is not installed, use of crypto disabled")
-
     class User(Enum):
         """
         Define some default users.


### PR DESCRIPTION
When someone imports opcua, he/she sees 3 same warnings, even in
opcua is not used. I see the reasoning behind this feature, so I
propose to move it in classes. 

If you have another proposal, let me know, I can change the commit