### PR TITLE
Adjusting Client Signature Algorithm (FreeOpcUa/python-opcua#811)

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -468,7 +468,7 @@ class Client(object):
         # the last serverNonce to the serverCertificate
         sig = uacrypto.sign_sha1(self.user_private_key, challenge)
         params.UserTokenSignature = ua.SignatureData()
-        params.UserTokenSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+        params.UserTokenSignature.Algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
         params.UserTokenSignature.Signature = sig
 
     def _add_user_auth(self, params, username, password):


### PR DESCRIPTION
I adjusted the string for die Client Signature Algorithm. As SHA1 is considered to be insecure, servers may reject encrypted connections when SHA1 is offered. Changing the algorithm to SHA256 seems to fix this issue.