### PR TITLE
Avoid exception in history subscription handler

### DIFF
--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from opcua import Subscription
 from opcua import ua
-from opcua.common import utils
+from opcua.common import utils, subscription
 
 
 class UaNodeAlreadyHistorizedError(ua.UaError):
@@ -172,7 +172,7 @@ class HistoryDict(HistoryStorageInterface):
         pass
 
 
-class SubHandler(object):
+class SubHandler(subscription.SubHandler):
     def __init__(self, storage):
         self.storage = storage
 


### PR DESCRIPTION
Avoid the following exception by properly subclassing
history.SubHandler.

ERROR:opcua.common.subscription:Exception calling status change handler
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/opcua/common/subscription.py", line 180, in _call_status
    self._handler.status_change_notification(status.Status)
AttributeError: 'SubHandler' object has no attribute 'status_change_notification'