### PR TITLE
Properly remove keepalive thread if session activation fails

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -276,11 +276,21 @@ class Client(object):
         try:
             self.send_hello()
             self.open_secure_channel()
-            self.create_session()
+            try:
+                self.create_session()
+                try:
+                    self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
+                except Exception:
+                    # clean up the session
+                    self.close_session()
+                    raise
+            except Exception:
+                # clean up the secure channel
+                self.close_secure_channel()
+                raise
         except Exception:
             self.disconnect_socket()  # clean up open socket
             raise
-        self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
 
     def disconnect(self):
         """


### PR DESCRIPTION
Previously we would have just raised an exception in case of
a session activiation failure (for example wrong password) but
the keepalive thread was kept running.

This change makes sure that all setup is torn down again in case
of a failure within "connect".

Hence, the library user can call connect() again if the previous
connect failed without having to explicitly clean up the half-baked
connect by calling disconnect.