### PR TITLE
Fixed: BadParentNodeIdInvalid when no parentlink

### DIFF
--- a/opcua/common/xmlimporter.py
+++ b/opcua/common/xmlimporter.py
@@ -145,8 +145,9 @@ class XmlImporter(object):
         node.BrowseName = self._migrate_ns(obj.browsename)
         self.logger.info("Importing xml node (%s, %s) as (%s %s)", obj.browsename, obj.nodeid, node.BrowseName, node.RequestedNewNodeId)
         node.NodeClass = getattr(ua.NodeClass, obj.nodetype[2:])
-        if obj.parent and obj.parentlink:
+        if obj.parent:
             node.ParentNodeId = self._migrate_ns(obj.parent)
+        if obj.parentlink:
             node.ReferenceTypeId = self._migrate_ns(obj.parentlink)
         if obj.typedef:
             node.TypeDefinition = self._migrate_ns(obj.typedef)


### PR DESCRIPTION
fixed  #1056 
When importing [Opc.Ua.AMLBaseTypes.NodeSet2.xml](https://github.com/OPCFoundation/UA-Nodeset/blob/master/AML/Opc.Ua.AMLBaseTypes.NodeSet2.xml), it raised BadParentNodeIdInvalid with information:
```
failure adding node NodeData(nodeid:NumericNodeId(ns=1;i=1010))
```