### PR TITLE
Honor option to instantiate optional children

### DIFF
--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -113,7 +113,8 @@ def _instantiate_node(server,
                             res.AddedNodeId,
                             c_rdesc,
                             nodeid=ua.NodeId(identifier=inst_nodeid, namespaceidx=res.AddedNodeId.NamespaceIndex),
-                            bname=c_rdesc.BrowseName)
+                            bname=c_rdesc.BrowseName,
+                            instantiate_optional=instantiate_optional)
                     else:
                         nodeids = _instantiate_node(
                             server,
@@ -121,7 +122,8 @@ def _instantiate_node(server,
                             res.AddedNodeId,
                             c_rdesc,
                             nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex),
-                            bname=c_rdesc.BrowseName)
+                            bname=c_rdesc.BrowseName,
+                            instantiate_optional=instantiate_optional)
                     added_nodes.extend(nodeids)
 
     return added_nodes


### PR DESCRIPTION
Previously, the flag in which the user specified whether or not to
instantiate optional children was only honored on the top-level object
(i.e., first recursion round)

Fixes #1087