### PR TITLE
Also treat OptionalPlaceholder ModellingRule as optional in `instantiate`

### DIFF
--- a/opcua/common/instantiate.py
+++ b/opcua/common/instantiate.py
@@ -100,7 +100,7 @@ def _instantiate_node(server,
                         logger.info("Instantiate: Skip node without modelling rule %s as part of %s", c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
-                    if not instantiate_optional and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                    if not instantiate_optional and refs[0].nodeid in (ua.NodeId(ua.ObjectIds.ModellingRule_Optional), ua.NodeId(ua.ObjectIds.ModellingRule_OptionalPlaceholder)):
                         logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName, addnode.BrowseName)
                         continue
 


### PR DESCRIPTION
`instantiate` with `instantiate_optional=False` would also instantiate
children that have the ModellingRule OptionalPlaceholder. So far, only
Optional children were ignored.

This commit fixes this behavior, and treats both of them the same w.r.t.
`instantiate_optional`.

Fixes #1092