### PR TITLE
Make sure all inverse references are removed on node deletion

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -330,7 +330,7 @@ class NodeManagementService(object):
 
         if item.DeleteTargetReferences:
             for elem in self._aspace.keys():
-                for rdesc in self._aspace[elem].references:
+                for rdesc in self._aspace[elem].references[:]:
                     if rdesc.NodeId == item.NodeId:
                         self._aspace[elem].references.remove(rdesc)
 

--- a/tests/tests_common.py
+++ b/tests/tests_common.py
@@ -118,6 +118,27 @@ class CommonTests(object):
         childs = fold.get_children()
         self.assertNotIn(var, childs)
 
+
+    def test_delete_nodes_with_inverse_references(self):
+        obj = self.opc.get_objects_node()
+        fold = obj.add_folder(2, "FolderToDelete")
+        var = fold.add_variable(2, "VarToDelete", 9.1)
+        var2 = fold.add_variable(2, "VarWithReference", 9.2)
+        childs = fold.get_children()
+        self.assertIn(var, childs)
+        self.assertIn(var2, childs)
+        # add two references to var, this includes adding the inverse references to var2
+        var.add_reference(var2.nodeid, reftype=ua.ObjectIds.HasDescription, forward=True, bidirectional=True)
+        var.add_reference(var2.nodeid, reftype=ua.ObjectIds.HasEffect, forward=True, bidirectional=True)
+        self.opc.delete_nodes([var])
+        childs = fold.get_children()
+        assert var not in childs
+        has_desc_refs = var2.get_referenced_nodes(refs=ua.ObjectIds.HasDescription, direction=ua.BrowseDirection.Inverse)
+        assert len(has_desc_refs) == 0
+        has_effect_refs = var2.get_referenced_nodes(refs=ua.ObjectIds.HasEffect, direction=ua.BrowseDirection.Inverse)
+        assert len(has_effect_refs) == 0
+
+
     def test_delete_nodes_recursive(self):
         obj = self.opc.get_objects_node()
         fold = obj.add_folder(2, "FolderToDeleteR")


### PR DESCRIPTION
Iterating over the references list and deleting inside the same list
resulted in dangling inverse references if nodes where deleted.

Fix this by iterating over a copy of the references list.