### PR TITLE
Update client.py

### DIFF
--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -469,16 +469,17 @@ class Client(object):
 
     def _add_certificate_auth(self, params, certificate, challenge):
         params.UserIdentityToken = ua.X509IdentityToken()
-        params.UserIdentityToken.PolicyId = self.server_policy_id(ua.UserTokenType.Certificate, "certificate_basic256")
         params.UserIdentityToken.CertificateData = uacrypto.der_from_x509(certificate)
         # specs part 4, 5.6.3.1: the data to sign is created by appending
         # the last serverNonce to the serverCertificate
         params.UserTokenSignature = ua.SignatureData()
         if certificate.signature_hash_algorithm.name == "sha256":
+            params.UserIdentityToken.PolicyId = self.server_policy_id(ua.UserTokenType.Certificate, "certificate_basic256sha256")
             sig = uacrypto.sign_sha256(self.user_private_key, challenge)
             params.UserTokenSignature.Algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
             params.UserTokenSignature.Signature = sig
         else:
+            params.UserIdentityToken.PolicyId = self.server_policy_id(ua.UserTokenType.Certificate, "certificate_basic256")
             sig = uacrypto.sign_sha1(self.user_private_key, challenge)
             params.UserTokenSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
             params.UserTokenSignature.Signature = sig

--- a/opcua/client/client.py
+++ b/opcua/client/client.py
@@ -473,10 +473,15 @@ class Client(object):
         params.UserIdentityToken.CertificateData = uacrypto.der_from_x509(certificate)
         # specs part 4, 5.6.3.1: the data to sign is created by appending
         # the last serverNonce to the serverCertificate
-        sig = uacrypto.sign_sha1(self.user_private_key, challenge)
         params.UserTokenSignature = ua.SignatureData()
-        params.UserTokenSignature.Algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
-        params.UserTokenSignature.Signature = sig
+        if certificate.signature_hash_algorithm.name == "sha256":
+            sig = uacrypto.sign_sha256(self.user_private_key, challenge)
+            params.UserTokenSignature.Algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+            params.UserTokenSignature.Signature = sig
+        else:
+            sig = uacrypto.sign_sha1(self.user_private_key, challenge)
+            params.UserTokenSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+            params.UserTokenSignature.Signature = sig
 
     def _add_user_auth(self, params, username, password):
         params.UserIdentityToken = ua.UserNameIdentityToken()


### PR DESCRIPTION
FreeOpcUa#778 Specify the signature algorithm URL for certificate authentication (and use it, too) that was actually used to sign the certificate from the key specified. That way, signature lengths match and a server-side check can succeed.