### PR TITLE
Move user_manager from Server into InternalServer

### DIFF
--- a/opcua/server/internal_server.py
+++ b/opcua/server/internal_server.py
@@ -39,10 +39,9 @@ class SessionState(Enum):
 
 class InternalServer(object):
 
-    def __init__(self, shelffile=None, parent=None, session_cls=None):
+    def __init__(self, shelffile=None, user_manager=None, session_cls=None):
         self.logger = logging.getLogger(__name__)
 
-        self._parent = parent
         self.server_callback_dispatcher = CallbackDispatcher()
 
         self.endpoints = []
@@ -63,6 +62,7 @@ class InternalServer(object):
         self.subscription_service = SubscriptionService(self.aspace)
 
         self.history_manager = HistoryManager(self)
+        self.user_manager = user_manager
 
         # create a session to use on server side
         self.session_cls = session_cls or InternalSession
@@ -72,10 +72,6 @@ class InternalServer(object):
         self.current_time_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
         self._address_space_fixes()
         self.setup_nodes()
-
-    @property
-    def user_manager(self):
-        return self._parent.user_manager
 
     @property
     def thread_loop(self):

--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -89,7 +89,7 @@ class Server(object):
         if iserver is not None:
             self.iserver = iserver
         else:
-            self.iserver = InternalServer(shelffile = shelffile, parent = self)
+            self.iserver = InternalServer(shelffile = shelffile)
         self.bserver = None
         self._policies = []
         self.nodes = Shortcuts(self.iserver.isession)
@@ -118,6 +118,14 @@ class Server(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.stop()
+
+    @property
+    def user_manager(self):
+        return self.iserver.user_manager
+
+    @user_manager.setter
+    def user_manager(self, user_manager):
+        self.iserver.user_manager = user_manager
 
     @property
     def local_discovery_service(self):


### PR DESCRIPTION
Removes the need to patch in the Server object via the _parent attribute
in InternalServer if the InternalServer is instantiated outside of
Server.__init__.

Before this commit, the Server object passed itself into the
InternalServer constructor. If we instantiate an InternalServer (that we
want to pass in) before the Server, we obviously don't have a Server
instance to pass in as the parent. So we end up having to do this:

>>> my_iserver = CustomInternalServer()
>>> server = Server(iserver = my_iserver)
>>> server.iserver._parent = server # <-- no longer necessary

To preserve compatibility and keep changes to a minimum, a user_manager
property and setter are added to the Server class which redirect to the
user_manager attribute of the internal server.