### PR TITLE
Fix get_server_node in Server

### DIFF
--- a/opcua/server/server.py
+++ b/opcua/server/server.py
@@ -377,7 +377,7 @@ class Server(object):
         """
         Get Server node of server. Returns a Node object.
         """
-        return self.get_node(ua.TwoByteNodeId(ua.ObjectIds.Server))
+        return self.get_node(ua.FourByteNodeId(ua.ObjectIds.Server))
 
     def get_node(self, nodeid):
         """


### PR DESCRIPTION
The NodeId of the Server node has the identifier 2253, which does not
fit in the range (0 < id < 255) required by the two byte NodeId encoding
(OPC-6 5.2.2.9). Use FourByteNodeId instead.

Client side is correct since 2cbd3339.