### PR TITLE
Reuse the same Variant(None) on emitting events for non-existant fields

### DIFF
--- a/opcua/common/events.py
+++ b/opcua/common/events.py
@@ -81,6 +81,7 @@ class Event(object):
         """
         return a field list using a select clause and the object properties
         """
+        none_field = ua.Variant(None, ua.VariantType.Null)
         fields = []
         for sattr in select_clauses:
             if not sattr.BrowsePath:
@@ -90,7 +91,7 @@ class Event(object):
             try:
                 val = getattr(self, name)
             except AttributeError:
-                field = ua.Variant(None)
+                field = none_field
             else:
                 field = ua.Variant(copy.deepcopy(val), self.data_types[name])
             fields.append(field)


### PR DESCRIPTION
Clients registering for multiple event types will usually construct a
select clause selecting _all_ fields of all subscribed events. For
example when subscribing for all events in server-events.py with
UaExport causes a ~200 field select clause.

When triggering an event we walk all requested fields in the select
clause (even though the event being triggered right now only has a few
of them).

In the server-events.py example this behavior causes quite some
overhead as from the ~200 requested fields only a few need to be
populated. For all other items a Variant(None) is instantiated.

Instead of instantiating a new Variant(None) for every none-existant
field we can just reuse the same instance for all none existant fields.

In my tests this caused a speed up >50% (~5ms -> ~2ms) for triggering
an event if a client with a large select clause is subscribed.