### PR TITLE
The OPCUA Server sets the Servertimestamp in the moment of writing th…

### DIFF
--- a/opcua/server/address_space.py
+++ b/opcua/server/address_space.py
@@ -10,7 +10,7 @@ except:
 
 from opcua import ua
 from opcua.server.user_manager import UserManager
-
+import pytz
 
 class AttributeValue(object):
 
@@ -63,6 +63,9 @@ class AttributeService(object):
                 if not ua.ua_binary.test_bit(al.Value.Value, ua.AccessLevel.CurrentWrite) or not ua.ua_binary.test_bit(ual.Value.Value, ua.AccessLevel.CurrentWrite):
                     res.append(ua.StatusCode(ua.StatusCodes.BadUserAccessDenied))
                     continue
+            tz = pytz.timezone('Europe/Berlin')
+            writevalue.Value.ServerTimestamp = datetime.now(tz)
+            #writevalue.Value.SourceTimestamp = datetime.now(tz)
             res.append(self._aspace.set_attribute_value(writevalue.NodeId, writevalue.AttributeId, writevalue.Value))
         return res
 


### PR DESCRIPTION
If you use an OPCUA Client such as UA Expert from Prosys and change values within the gui than the Servertimestamp is not set while writing the node, which is from our perspective not as specified by the OPCUA guidelines.
The Timestamp will be set to EPOCH Time which is on Windows in the year 1601.
The bug is contained in address_space.py in the write function. There the datavalue for Servertimestamp should be set before writing the node.

See: [(https://github.com/FreeOpcUa/python-opcua/issues/1192)]

If the Sourcetimestamp is not set by the client, you can use the commented line with SourceTimestamp as well.