### PR TITLE
Use environment markers for install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,14 @@ from setuptools import setup, find_packages
 
 import sys
 
-install_requires = ["python-dateutil", "pytz", "lxml"]
-if sys.version_info[0] < 3:
-    install_requires.extend(["enum34", "trollius", "futures"])
+install_requires = [
+    "lxml",
+    "python-dateutil",
+    "pytz",
+    "enum34; python_version < '3'",
+    "futures; python_version < '3'",
+    "trollius; python_version < '3'",
+]
 
 setup(name="opcua",
       version="0.98.12",
@@ -43,4 +48,3 @@ setup(name="opcua",
                     ]
                     }
       )
-


### PR DESCRIPTION
This issue was first discovered when trying to install `opcua` using [poetry](https://python-poetry.org/).

This can be reproduced using the following

```sh
mkvirtualenv foo --python 3.7
pip install poetry
poetry init
poetry add opcua
```
where the following error is encountered
```sh
Package operations: 8 installs, 0 updates, 0 removals

  • Installing futures (3.1.1)
  • Installing six (1.15.0)
  • Installing enum34 (1.1.10)
  • Installing lxml (4.6.2)
  • Installing python-dateutil (2.8.1)
  • Installing pytz (2021.1)
  • Installing trollius (2.2): Failed

  RuntimeError

  Unable to find installation candidates for trollius (2.2)

  at ~/.virtual_envs/foo/lib/python3.7/site-packages/poetry/installation/chooser.py:73 in choose_for
       69│             links.append(link)
       70│ 
       71│         if not links:
       72│             raise RuntimeError(
    →  73│                 "Unable to find installation candidates for {}".format(package)
       74│             )
       75│ 
       76│         # Get the best link
       77│         chosen = max(links, key=lambda link: self._sort_key(package, link))


Failed to add packages, reverting the pyproject.toml file to its original content.
```

meaning, it tried to install the python 2 dependencies as well. Here is a post from the maintainer of `poetry` on a ticket for a similar issue https://github.com/python-poetry/poetry/issues/844#issuecomment-458178991 with a recommendation to use [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers) to fix the issue.