### PR TITLE
Fix invalid xml serialization of DateTime value

### DIFF
--- a/opcua/common/xmlexporter.py
+++ b/opcua/common/xmlexporter.py
@@ -377,6 +377,8 @@ class XmlExporter(object):
                 val = b""
             data = base64.b64encode(val)
             el.text = data.decode("utf-8")
+        elif dtype == ua.NodeId(ua.ObjectIds.DateTime):
+            el.text = val.isoformat()
         elif not hasattr(val, "ua_types"):
             if isinstance(val, bytes):
                 # FIXME: should we also encode this (localized text I guess) using base64??


### PR DESCRIPTION
 Fix invalid xml serialization of DateTime value

 Serialization emitted wrong string for the XML dateTime type

Wrong: <uax:DateTime>2020-01-31 12:00:00</uax:DateTime>
Correct: <uax:DateTime>2020-01-31T12:00:00</uax:DateTime>

Notice the missing T seperator in the text representation of the value attribute.

In XML the parser expects a string according to this format.
https://www.w3.org/TR/xmlschema-2/#dateTime

Fixes issue #1343