### PR TITLE
ignore emtpy locale

### DIFF
--- a/opcua/ua/uatypes.py
+++ b/opcua/ua/uatypes.py
@@ -554,7 +554,7 @@ class LocalizedText(FrozenClass):
     def to_string(self):
         if self.Text is None:
             return ""
-        if self.Locale is None:
+        if not self.Locale:
             return self.Text
         return self.__str__()
     


### PR DESCRIPTION
If locale is set to emtpy string, to not localize text.  Fixes display of names in opcua-client-gui.  Regression introduced in 6ce82545e6aa91d42105b2ae902e18b01ff028bb