### PR TITLE
Fix history continuation point calculation.

### DIFF
--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -123,7 +123,7 @@ class HistoryDict(HistoryStorageInterface):
             else:
                 results = [dv for dv in self._datachanges[node_id] if start <= dv.SourceTimestamp <= end]
             if nb_values and len(results) > nb_values:
-                cont = results[nb_values + 1].SourceTimestamp
+                cont = results[nb_values].SourceTimestamp
                 results = results[:nb_values]
             return results, cont
 
@@ -164,7 +164,7 @@ class HistoryDict(HistoryStorageInterface):
             else:
                 results = [ev for ev in self._events[source_id] if start <= ev.Time <= end]
             if nb_values and len(results) > nb_values:
-                cont = results[nb_values + 1].Time
+                cont = results[nb_values].Time
                 results = results[:nb_values]
             return results, cont
 


### PR DESCRIPTION
I believe there is an off-by-one error in calculation of history continuation point.

Same as in https://github.com/FreeOpcUa/opcua-asyncio/pull/1131

For example, I have a var on server with history of values [0, 1, 2, 3, 4, 5].
When I read history of that variable in portions of maxlen=3 with the use of continuation point, I get: [0, 1, 2], [4, 5]. The value 3 is never returned.

With the fix I get: [0, 1, 2], [3, 4, 5] as expected.